### PR TITLE
Add BM25 and BM25_GLOBAL scoring methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `SingleStoreSQLDatabaseRetriever` enables LangChain agents and chains to exe
 #### Basic Usage
 
 ```python
-from langchain_singlestore.vectorstores import SingleStoreVectorStore
+from langchain_singlestore import SingleStoreVectorStore
 from langchain_core.documents import Document
 from langchain_openai import OpenAIEmbeddings
 
@@ -189,41 +189,41 @@ results = vector_store.similarity_search(
 Configure different search strategies based on your use case:
 
 ```python
-from langchain_singlestore._utils import SearchStrategy
+from langchain_singlestore import SingleStoreVectorStore
 
 # Strategy 1: Vector search only (fastest)
 results = vector_store.similarity_search(
     query="landmarks",
     k=5,
-    search_strategy=SearchStrategy.VECTOR_ONLY
+    search_strategy=SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY
 )
 
 # Strategy 2: Full-text search only (best for keyword matching)
 results = vector_store.similarity_search(
     query="Eiffel",
     k=5,
-    search_strategy=SearchStrategy.TEXT_ONLY
+    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY
 )
 
 # Strategy 3: Filter by text, then rank by vector (hybrid)
 results = vector_store.similarity_search(
     query="landmarks in paris",
     k=5,
-    search_strategy=SearchStrategy.FILTER_BY_TEXT  # Text match required
+    search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT  # Text match required
 )
 
 # Strategy 4: Filter by vector, then rank by text
 results = vector_store.similarity_search(
     query="iconic structures",
     k=5,
-    search_strategy=SearchStrategy.FILTER_BY_VECTOR
+    search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR
 )
 
 # Strategy 5: Weighted combination (balanced approach)
 results = vector_store.similarity_search(
     query="famous landmarks",
     k=5,
-    search_strategy=SearchStrategy.WEIGHTED_SUM  # Combines vector + text scores
+    search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM  # Combines vector + text scores
 )
 ```
 
@@ -232,8 +232,7 @@ results = vector_store.similarity_search(
 SingleStore supports two versions of full-text indexes with different capabilities:
 
 ```python
-from langchain_singlestore.vectorstores import SingleStoreVectorStore
-from langchain_singlestore._utils import FullTextIndexVersion
+from langchain_singlestore import SingleStoreVectorStore, FullTextIndexVersion
 from langchain_openai import OpenAIEmbeddings
 
 # Version 1 (V1) - Compatible with all SingleStore versions
@@ -269,8 +268,11 @@ vector_store_v2 = SingleStoreVectorStore(
 When using full-text search strategies (TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, WEIGHTED_SUM), you can choose different scoring algorithms:
 
 ```python
-from langchain_singlestore.vectorstores import SingleStoreVectorStore
-from langchain_singlestore._utils import FullTextIndexVersion, FullTextScoringMode
+from langchain_singlestore import (
+    SingleStoreVectorStore,
+    FullTextIndexVersion,
+    FullTextScoringMode,
+)
 from langchain_openai import OpenAIEmbeddings
 
 # Initialize with V2 full-text index (required for BM25 modes)
@@ -333,7 +335,7 @@ The `SingleStoreLoader` class provides efficient loading of documents directly f
 - Support for complex metadata structures
 
 ```python
-from langchain_singlestore.document_loaders import SingleStoreLoader
+from langchain_singlestore import SingleStoreLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 # Initialize loader

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ The `SingleStoreVectorStore` class provides a powerful document storage and retr
 - Multiple search strategies (VECTOR_ONLY, TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, WEIGHTED_SUM)
 - Simple and advanced metadata filtering
 - Efficient document management (add, delete, update)
-- Configurable distance metrics
+- Configurable distance metrics (DOT_PRODUCT, EUCLIDEAN_DISTANCE)
+- Full-text index versions (V1, V2) with different capabilities
+- Multiple text scoring algorithms (MATCH, BM25, BM25_GLOBAL)
 
 ### SQL Database Retriever
 
@@ -56,15 +58,9 @@ The `SingleStoreSQLDatabaseRetriever` enables LangChain agents and chains to exe
 - Integration with LangChain agents for database-aware AI
 - Support for complex queries with JSON results
 
-### Document Loader
+## Usage Examples
 
-The `SingleStoreLoader` class provides efficient loading of documents directly from SingleStore database tables.
-
-**Key Features:**
-- Load documents from any database table
-- Configurable content and metadata fields
-- Efficient batch processing
-- Support for complex metadata structures
+### Vector Store
 
 #### Basic Usage
 
@@ -230,6 +226,101 @@ results = vector_store.similarity_search(
     search_strategy=SearchStrategy.WEIGHTED_SUM  # Combines vector + text scores
 )
 ```
+
+#### Full-Text Index Versions
+
+SingleStore supports two versions of full-text indexes with different capabilities:
+
+```python
+from langchain_singlestore.vectorstores import SingleStoreVectorStore
+from langchain_singlestore._utils import FullTextIndexVersion
+from langchain_openai import OpenAIEmbeddings
+
+# Version 1 (V1) - Compatible with all SingleStore versions
+# Uses the original full-text index implementation
+vector_store_v1 = SingleStoreVectorStore(
+    embedding=OpenAIEmbeddings(),
+    host="127.0.0.1:3306/db",
+    use_full_text_search=True,
+    full_text_index_version=FullTextIndexVersion.V1,  # Default
+)
+
+# Version 2 (V2) - Requires SingleStore 8.7+
+# Offers improved performance and additional features like BM25 scoring
+vector_store_v2 = SingleStoreVectorStore(
+    embedding=OpenAIEmbeddings(),
+    host="127.0.0.1:3306/db",
+    use_full_text_search=True,
+    full_text_index_version=FullTextIndexVersion.V2,
+)
+```
+
+**Version Comparison:**
+
+| Feature | V1 | V2 |
+|---------|----|----|  
+| SingleStore Compatibility | All versions | 8.7+ |
+| MATCH scoring | ✓ | ✓ |
+| BM25 scoring | ✗ | ✓ |
+| BM25_GLOBAL scoring | ✗ | ✓ |
+
+#### Full-Text Scoring Modes
+
+When using full-text search strategies (TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, WEIGHTED_SUM), you can choose different scoring algorithms:
+
+```python
+from langchain_singlestore.vectorstores import SingleStoreVectorStore
+from langchain_singlestore._utils import FullTextIndexVersion, FullTextScoringMode
+from langchain_openai import OpenAIEmbeddings
+
+# Initialize with V2 full-text index (required for BM25 modes)
+vector_store = SingleStoreVectorStore(
+    embedding=OpenAIEmbeddings(),
+    host="127.0.0.1:3306/db",
+    use_full_text_search=True,
+    full_text_index_version=FullTextIndexVersion.V2,
+)
+
+# MATCH mode (default) - Works with V1 and V2
+# Uses native MATCH() AGAINST() function
+results = vector_store.similarity_search(
+    query="famous landmarks",
+    k=5,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+    full_text_scoring_mode=FullTextScoringMode.MATCH,
+)
+
+# BM25 mode - Requires V2
+# Uses BM25 algorithm with TF-IDF and document length normalization
+results = vector_store.similarity_search(
+    query="famous landmarks",
+    k=5,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+    full_text_scoring_mode=FullTextScoringMode.BM25,
+)
+
+# BM25_GLOBAL mode - Requires V2
+# Computes IDF statistics across the entire dataset (more accurate in distributed environments)
+results = vector_store.similarity_search(
+    query="famous landmarks",
+    k=5,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+    full_text_scoring_mode=FullTextScoringMode.BM25_GLOBAL,
+)
+```
+
+**Scoring Mode Comparison:**
+
+| Mode | Description | Index Version | Use Case |
+|------|-------------|---------------|----------|
+| MATCH | Native SingleStore MATCH() function | V1, V2 | General text search, backward compatibility |
+| BM25 | Best Matching 25 algorithm | V2 only | More accurate relevance scoring with TF-IDF |
+| BM25_GLOBAL | BM25 with global IDF statistics | V2 only | Consistent scoring in distributed/sharded environments |
+
+**When to use each mode:**
+- **MATCH**: Default mode. Fast, simple keyword matching. Good for basic search needs.
+- **BM25**: Better relevance ranking by considering term frequency, inverse document frequency, and document length. Recommended for most text search applications.
+- **BM25_GLOBAL**: Same as BM25 but calculates statistics globally across all partitions. Use when you need consistent scoring across a distributed SingleStore cluster.
 
 ### Document Loader
 

--- a/langchain_singlestore/__init__.py
+++ b/langchain_singlestore/__init__.py
@@ -1,6 +1,11 @@
 from importlib import metadata
 
 from langchain_singlestore._filter import FilterTypedDict
+from langchain_singlestore._utils import (
+    DistanceStrategy,
+    FullTextIndexVersion,
+    FullTextScoringMode,
+)
 from langchain_singlestore.cache import SingleStoreSemanticCache
 from langchain_singlestore.chat_message_history import SingleStoreChatMessageHistory
 from langchain_singlestore.document_loaders import SingleStoreLoader
@@ -25,5 +30,8 @@ __all__ = [
     "SingleStoreSQLDatabaseRetriever",
     "SingleStoreSQLDatabaseChain",
     "FilterTypedDict",
+    "FullTextScoringMode",
+    "FullTextIndexVersion",
+    "DistanceStrategy",
     "__version__",
 ]

--- a/langchain_singlestore/_utils.py
+++ b/langchain_singlestore/_utils.py
@@ -39,22 +39,49 @@ def set_connector_attributes(connection_kwargs: dict) -> None:
 
 
 class DistanceStrategy(str, Enum):
-    """Enumerator of the Distance strategies for calculating distances
-    between vectors."""
+    """Distance strategies for calculating similarity between vectors.
+
+    Attributes:
+        EUCLIDEAN_DISTANCE: Computes the Euclidean (L2) distance between vectors.
+            Lower scores indicate more similar vectors. Not compatible with
+            WEIGHTED_SUM search strategy.
+        DOT_PRODUCT: Computes the dot product (inner product) between vectors.
+            Higher scores indicate more similar vectors. This is the default
+            and recommended strategy for most embedding models.
+    """
 
     EUCLIDEAN_DISTANCE = "EUCLIDEAN_DISTANCE"
     DOT_PRODUCT = "DOT_PRODUCT"
 
 
 class FullTextIndexVersion(str, Enum):
-    """Enumerator of the Full-Text Index versions"""
+    """Full-text index versions supported by SingleStore.
+
+    Attributes:
+        V1: Original full-text index implementation. Compatible with all
+            SingleStore versions that support full-text search. Only supports
+            MATCH scoring mode.
+        V2: New full-text index implementation available in SingleStore 8.7+.
+            Offers improved performance and supports additional scoring modes
+            (BM25, BM25_GLOBAL).
+    """
 
     V1 = "V1"
     V2 = "V2"
 
 
 class FullTextScoringMode(str, Enum):
-    """Enumerator of the Full-Text Scoring Modes"""
+    """Scoring algorithms for full-text search ranking.
+
+    Attributes:
+        MATCH: Uses SingleStore's native MATCH() AGAINST() function.
+            Compatible with both V1 and V2 full-text indexes.
+        BM25: Best Matching 25 algorithm with TF-IDF scoring and document
+            length normalization. Requires V2 full-text index.
+        BM25_GLOBAL: BM25 with global IDF statistics across all partitions.
+            Provides consistent scoring in distributed environments.
+            Requires V2 full-text index.
+    """
 
     MATCH = "MATCH"
     BM25 = "BM25"

--- a/langchain_singlestore/_utils.py
+++ b/langchain_singlestore/_utils.py
@@ -53,6 +53,14 @@ class FullTextIndexVersion(str, Enum):
     V2 = "V2"
 
 
+class FullTextScoringMode(str, Enum):
+    """Enumerator of the Full-Text Scoring Modes"""
+
+    MATCH = "MATCH"
+    BM25 = "BM25"
+    BM25_GLOBAL = "BM25_GLOBAL"
+
+
 def hash(_input: str) -> str:
     """Use a deterministic hashing approach."""
     return hashlib.md5(_input.encode()).hexdigest()

--- a/langchain_singlestore/chat_message_history.py
+++ b/langchain_singlestore/chat_message_history.py
@@ -101,7 +101,7 @@ class SingleStoreChatMessageHistory(BaseChatMessageHistory):
 
             .. code-block:: python
 
-                from langchain_community.chat_message_histories import (
+                from langchain_singlestore import (
                     SingleStoreDBChatMessageHistory
                 )
 
@@ -114,7 +114,7 @@ class SingleStoreChatMessageHistory(BaseChatMessageHistory):
 
             .. code-block:: python
 
-                from langchain_community.chat_message_histories import (
+                from langchain_singlestore import (
                     SingleStoreDBChatMessageHistory
                 )
 
@@ -134,7 +134,7 @@ class SingleStoreChatMessageHistory(BaseChatMessageHistory):
 
             .. code-block:: python
 
-                from langchain_community.chat_message_histories import (
+                from langchain_singlestore import (
                     SingleStoreDBChatMessageHistory
                 )
 

--- a/langchain_singlestore/document_loaders.py
+++ b/langchain_singlestore/document_loaders.py
@@ -28,7 +28,7 @@ class SingleStoreLoader(BaseLoader):
         Instantiate:
             .. code-block:: python
 
-                from langchain_community.document_loaders import SingleStoreLoader
+                from langchain_singlestore import SingleStoreLoader
 
                 loader = SingleStoreLoader(
                     host="https://user:password@127.0.0.1:3306/database",

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -819,6 +819,24 @@ class SingleStoreVectorStore(VectorStore):
         )
         return [doc for doc, _ in docs_and_scores]
 
+    def _fulltext_scoring_mode_to_sql(
+        self,
+        mode: FullTextScoringMode,
+        query: str,
+    ) -> tuple[str, str]:
+        """Convert the full text scoring mode to the corresponding SQL snippet."""
+        match_arg = self.content_field
+        search_query = query
+        if self.full_text_index_version != FullTextIndexVersion.V1:
+            search_query = "{}:({})".format(self.content_field, query)
+            match_arg = self.table_name
+            if mode == FullTextScoringMode.MATCH:
+                match_arg = "TABLE {}".format(self.table_name)
+        if mode == FullTextScoringMode.MATCH:
+            return "MATCH ({}) AGAINST (%s)".format(match_arg), search_query
+        else:
+            return "{}({}, %s)".format(mode.value, match_arg), search_query
+
     def similarity_search_with_score(
         self,
         query: str,
@@ -1030,15 +1048,11 @@ class SingleStoreVectorStore(VectorStore):
             arguments = []
 
             if search_strategy == SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT:
-                match_arg = self.content_field
-                if self.full_text_index_version == FullTextIndexVersion.V1:
-                    where_clause_values.append(query)
-                else:
-                    where_clause_values.append(
-                        "{}:({})".format(self.content_field, query)
-                    )
-                    match_arg = "TABLE {}".format(self.table_name)
-                arguments.append("MATCH ({}) AGAINST (%s) > %s".format(match_arg))
+                function_sql, search_query = self._fulltext_scoring_mode_to_sql(
+                    full_text_scoring_mode, query
+                )
+                arguments.append("{} > %s".format(function_sql))
+                where_clause_values.append(search_query)
                 where_clause_values.append(float(filter_threshold))
 
             if (
@@ -1107,19 +1121,18 @@ class SingleStoreVectorStore(VectorStore):
                     or search_strategy
                     == SingleStoreVectorStore.SearchStrategy.TEXT_ONLY
                 ):
-                    full_text_query = query
-                    match_arg = self.content_field
-                    if self.full_text_index_version != FullTextIndexVersion.V1:
-                        match_arg = "TABLE {}".format(self.table_name)
-                        full_text_query = "{}:({})".format(self.content_field, query)
-
+                    fulltext_score_query, full_text_query = (
+                        self._fulltext_scoring_mode_to_sql(
+                            full_text_scoring_mode, query
+                        )
+                    )
                     cur.execute(
-                        """SELECT {}, {}, {}, MATCH ({}) AGAINST (%s) as __score
+                        """SELECT {}, {}, {}, {} as __score
                         FROM {} {} ORDER BY __score DESC LIMIT %s""".format(
                             self.content_field,
                             self.metadata_field,
                             self.id_field,
-                            match_arg,
+                            fulltext_score_query,
                             self.table_name,
                             where_clause,
                         ),
@@ -1129,15 +1142,15 @@ class SingleStoreVectorStore(VectorStore):
                     search_strategy
                     == SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM
                 ):
-                    full_text_query = query
-                    match_arg = self.content_field
-                    if self.full_text_index_version != FullTextIndexVersion.V1:
-                        full_text_query = "{}:({})".format(self.content_field, query)
-                        match_arg = "TABLE {}".format(self.table_name)
+                    fulltext_score_query, full_text_query = (
+                        self._fulltext_scoring_mode_to_sql(
+                            full_text_scoring_mode, query
+                        )
+                    )
                     cur.execute(
                         """SELECT {}, {}, r1.{} as {}, __score1 * %s + __score2 * %s
                         as __score FROM (
-                            SELECT {}, {}, {}, MATCH ({}) AGAINST (%s) as __score1 
+                            SELECT {}, {}, {}, {} as __score1
                         FROM {} {}) r1 FULL OUTER JOIN (
                             SELECT {}, {}({}, JSON_ARRAY_PACK(%s)) as __score2
                             FROM {} {} ORDER BY __score2 {} LIMIT %s
@@ -1149,7 +1162,7 @@ class SingleStoreVectorStore(VectorStore):
                             self.id_field,
                             self.content_field,
                             self.metadata_field,
-                            match_arg,
+                            fulltext_score_query,
                             self.table_name,
                             where_clause,
                             self.id_field,

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -335,7 +335,7 @@ class SingleStoreVectorStore(VectorStore):
                 from langchain_openai import OpenAIEmbeddings
                 from langchain_singlestore import SingleStoreVectorStore
 
-                vectorstore = SingleStoreVectorStor(
+                vectorstore = SingleStoreVectorStore(
                     OpenAIEmbeddings(),
                     host="https://user:password@127.0.0.1:3306/database"
                 )
@@ -971,9 +971,9 @@ class SingleStoreVectorStore(VectorStore):
             .. code-block:: python
 
                 from langchain_singlestore import (
-                    SingleStoreVectorStore
+                    SingleStoreVectorStore,
                     FullTextIndexVersion,
-                    FullTextScoringMode
+                    FullTextScoringMode,
                 )
                 from langchain_openai import OpenAIEmbeddings
 

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -389,6 +389,7 @@ class SingleStoreVectorStore(VectorStore):
             Using full-text index:
 
             .. code-block:: python
+
                 from langchain_openai import OpenAIEmbeddings
                 from langchain_singlestore import SingleStoreVectorStore
 
@@ -665,7 +666,8 @@ class SingleStoreVectorStore(VectorStore):
     ) -> List[Document]:
         """Returns the most similar indexed documents to the query text.
 
-        Uses cosine similarity.
+        Uses the configured distance_strategy (DOT_PRODUCT or EUCLIDEAN_DISTANCE)
+        to measure similarity between vectors.
 
         Args:
             query (str): The query text for which to find similar documents.
@@ -857,7 +859,10 @@ class SingleStoreVectorStore(VectorStore):
         full_text_scoring_mode: FullTextScoringMode = FullTextScoringMode.MATCH,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
-        """Return docs most similar to query. Uses cosine similarity.
+        """Return docs most similar to query.
+
+        Uses the configured distance_strategy (DOT_PRODUCT or EUCLIDEAN_DISTANCE)
+        to measure similarity between vectors.
 
         Args:
             query: Text to look up documents similar to.

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -850,7 +850,7 @@ class SingleStoreVectorStore(VectorStore):
         k: int = 4,
         filter: Optional[Union[dict, FilterTypedDict]] = None,
         search_strategy: SearchStrategy = SearchStrategy.VECTOR_ONLY,
-        filter_threshold: float = 1,
+        filter_threshold: float = 0,
         text_weight: float = 0.5,
         vector_weight: float = 0.5,
         vector_select_count_multiplier: int = 10,

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -1314,9 +1314,8 @@ class SingleStoreVectorStore(VectorStore):
                 - V2: Uses the new full-text index implementation introduced in
                     SingleStore 8.7. This version offers improved performance and
                     additional features, but is only compatible with SingleStore 8.7
-                    or later. If use_full_text_search is set to True and the
-                    SingleStore version is 8.7 or later, this will be used as the
-                    default value.
+                    or later. To use this version, it must be explicitly passed as
+                    the value of full_text_index_version.
 
             pool_size (int, optional): Determines the number of active connections in
                 the pool. Defaults to 5.

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -333,7 +333,7 @@ class SingleStoreVectorStore(VectorStore):
             .. code-block:: python
 
                 from langchain_openai import OpenAIEmbeddings
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
 
                 vectorstore = SingleStoreVectorStor(
                     OpenAIEmbeddings(),
@@ -345,7 +345,10 @@ class SingleStoreVectorStore(VectorStore):
             .. code-block:: python
 
                 from langchain_openai import OpenAIEmbeddings
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import (
+                    SingleStoreVectorStore,
+                    DistanceStrategy,
+                )
 
                 vectorstore = SingleStoreVectorStore(
                     OpenAIEmbeddings(),
@@ -365,7 +368,7 @@ class SingleStoreVectorStore(VectorStore):
             .. code-block:: python
 
                 from langchain_openai import OpenAIEmbeddings
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
 
                 os.environ['SingleStore_URL'] = 'me:p455w0rd@s2-host.com/my_db'
                 vectorstore = SingleStoreVectorStore(OpenAIEmbeddings())
@@ -375,7 +378,7 @@ class SingleStoreVectorStore(VectorStore):
             .. code-block:: python
 
                 from langchain_openai import OpenAIEmbeddings
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
 
                 os.environ['SingleStore_URL'] = 'me:p455w0rd@s2-host.com/my_db'
                 vectorstore = SingleStoreVectorStore(
@@ -387,7 +390,7 @@ class SingleStoreVectorStore(VectorStore):
 
             .. code-block:: python
                 from langchain_openai import OpenAIEmbeddings
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
 
                 os.environ['SingleStore_URL'] = 'me:p455w0rd@s2-host.com/my_db'
                 vectorstore = SingleStoreVectorStore(
@@ -756,7 +759,7 @@ class SingleStoreVectorStore(VectorStore):
             Basic Usage:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -770,7 +773,7 @@ class SingleStoreVectorStore(VectorStore):
             Different Search Strategies:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -787,7 +790,11 @@ class SingleStoreVectorStore(VectorStore):
             Weighted Sum Search Strategy:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import (
+                    SingleStoreVectorStore,
+                    FullTextScoringMode,
+                    FullTextIndexVersion,
+                )
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -948,7 +955,7 @@ class SingleStoreVectorStore(VectorStore):
             Basic Usage:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -963,7 +970,11 @@ class SingleStoreVectorStore(VectorStore):
 
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import (
+                    SingleStoreVectorStore
+                    FullTextIndexVersion,
+                    FullTextScoringMode
+                )
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -984,7 +995,7 @@ class SingleStoreVectorStore(VectorStore):
             Weighted Sum Search Strategy:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_documents(
@@ -1372,7 +1383,7 @@ class SingleStoreVectorStore(VectorStore):
         Example:
             .. code-block:: python
 
-                from langchain_community.vectorstores import SingleStoreVectorStore
+                from langchain_singlestore import SingleStoreVectorStore
                 from langchain_openai import OpenAIEmbeddings
 
                 s2 = SingleStoreVectorStore.from_texts(

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -1003,6 +1003,16 @@ class SingleStoreVectorStore(VectorStore):
                 )
             )
 
+        if (
+            full_text_scoring_mode != FullTextScoringMode.MATCH
+            and self.full_text_index_version != FullTextIndexVersion.V2
+        ):
+            raise ValueError(
+                "Scoring {} is not supported with full-text index version {}".format(
+                    full_text_scoring_mode, self.full_text_index_version
+                )
+            )
+
         # Creates embedding vector from user query
         embedding = []
         if search_strategy != SingleStoreVectorStore.SearchStrategy.TEXT_ONLY:

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -1067,6 +1067,7 @@ class SingleStoreVectorStore(VectorStore):
         vector_index_options: Optional[dict] = None,
         vector_size: int = 1536,
         use_full_text_search: bool = False,
+        full_text_index_version: FullTextIndexVersion = DEFAULT_FULL_TEXT_INDEX_VERSION,
         pool_size: int = 5,
         max_overflow: int = 10,
         timeout: float = 30,
@@ -1129,6 +1130,19 @@ class SingleStoreVectorStore(VectorStore):
                 FILTER_BY_TEXT, FILTER_BY_VECTOR, and WEIGHTED_SUM search strategies.
                 If set to False, the similarity_search method will only allow
                 VECTOR_ONLY search strategy.
+            full_text_index_version (FullTextIndexVersion, optional): Determines the
+                version of the full-text index to use. Defaults to V1.
+                Available options are:
+                - V1: Uses the original full-text index implementation. This version
+                    is compatible with all versions of SingleStore, but does not
+                    support some of the advanced features of the full-text search,
+                    such as boolean mode and query expansion.
+                - V2: Uses the new full-text index implementation introduced in
+                    SingleStore 8.7. This version offers improved performance and
+                    additional features, but is only compatible with SingleStore 8.7
+                    or later. If use_full_text_search is set to True and the
+                    SingleStore version is 8.7 or later, this will be used as the
+                    default value.
 
             pool_size (int, optional): Determines the number of active connections in
                 the pool. Defaults to 5.
@@ -1194,6 +1208,7 @@ class SingleStoreVectorStore(VectorStore):
             vector_index_options=vector_index_options,
             vector_size=vector_size,
             use_full_text_search=use_full_text_search,
+            full_text_index_version=full_text_index_version,
             **kwargs,
         )
         instance.add_texts(texts, metadatas, embedding.embed_documents(texts), **kwargs)

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -28,6 +28,7 @@ from langchain_singlestore._filter import FilterTypedDict, _parse_filter
 from langchain_singlestore._utils import (
     DistanceStrategy,
     FullTextIndexVersion,
+    FullTextScoringMode,
     set_connector_attributes,
 )
 
@@ -85,8 +86,11 @@ def _apply_filter_to_where_clause(
 
     Args:
         metadata_field: Name of the metadata field in the database
+
         filter_dict: Filter specification (simple dict or FilterTypedDict)
+
         where_clause_values: List to accumulate parameter values for SQL
+
         arguments: List to accumulate SQL WHERE clause conditions
     """
     if not filter_dict:
@@ -181,10 +185,14 @@ class SingleStoreVectorStore(VectorStore):
             distance_strategy (DistanceStrategy, optional):
                 Determines the strategy employed for calculating
                 the distance between vectors in the embedding space.
+
                 Defaults to DOT_PRODUCT.
+
                 Available options are:
+
                 - DOT_PRODUCT: Computes the scalar product of two vectors.
                     This is the default behavior
+
                 - EUCLIDEAN_DISTANCE: Computes the Euclidean distance between
                     two vectors. This metric considers the geometric distance in
                     the vector space, and might be more suitable for embeddings
@@ -193,12 +201,16 @@ class SingleStoreVectorStore(VectorStore):
 
             table_name (str, optional): Specifies the name of the table in use.
                 Defaults to "embeddings".
+
             content_field (str, optional): Specifies the field to store the content.
                 Defaults to "content".
+
             metadata_field (str, optional): Specifies the field to store metadata.
                 Defaults to "metadata".
+
             vector_field (str, optional): Specifies the field to store the vector.
                 Defaults to "vector".
+
             id_field (str, optional): Specifies the field to store the id.
                 Defaults to "id".
 
@@ -214,7 +226,9 @@ class SingleStoreVectorStore(VectorStore):
                 the vector index. Defaults to {}.
                 Will be ignored if use_vector_index is set to False. The options are:
                 index_type (str, optional): Specifies the type of the index.
-                    Defaults to IVF_PQFS.
+
+                Defaults to IVF_PQFS.
+
                 For more options, please refer to the SingleStore documentation:
                 https://docs.singlestore.com/cloud/reference/sql-reference/vector-functions/vector-indexing/
 
@@ -243,50 +257,73 @@ class SingleStoreVectorStore(VectorStore):
                     performance and additional features, but is not compatible with
                     SingleStore versions prior to 8.7.
 
+
             Following arguments pertain to the connection pool:
 
             pool_size (int, optional): Determines the number of active connections in
                 the pool. Defaults to 5.
+
             max_overflow (int, optional): Determines the maximum number of connections
                 allowed beyond the pool_size. Defaults to 10.
+
             timeout (float, optional): Specifies the maximum wait time in seconds for
                 establishing a connection. Defaults to 30.
+
 
             Following arguments pertain to the database connection:
 
             host (str, optional): Specifies the hostname, IP address, or URL for the
                 database connection. The default scheme is "mysql".
+
             user (str, optional): Database username.
+
             password (str, optional): Database password.
+
             port (int, optional): Database port. Defaults to 3306 for non-HTTP
                 connections, 80 for HTTP connections, and 443 for HTTPS connections.
+
             database (str, optional): Database name.
+
 
             Additional optional arguments provide further customization over the
             database connection:
 
             pure_python (bool, optional): Toggles the connector mode. If True,
                 operates in pure Python mode.
+
             local_infile (bool, optional): Allows local file uploads.
+
             charset (str, optional): Specifies the character set for string values.
+
             ssl_key (str, optional): Specifies the path of the file containing the SSL
                 key.
+
             ssl_cert (str, optional): Specifies the path of the file containing the SSL
                 certificate.
+
             ssl_ca (str, optional): Specifies the path of the file containing the SSL
                 certificate authority.
+
             ssl_cipher (str, optional): Sets the SSL cipher list.
+
             ssl_disabled (bool, optional): Disables SSL usage.
+
             ssl_verify_cert (bool, optional): Verifies the server's certificate.
                 Automatically enabled if ``ssl_ca`` is specified.
+
             ssl_verify_identity (bool, optional): Verifies the server's identity.
+
             conv (dict[int, Callable], optional): A dictionary of data conversion
                 functions.
+
             credential_type (str, optional): Specifies the type of authentication to
                 use: auth.PASSWORD, auth.JWT, or auth.BROWSER_SSO.
+
             autocommit (bool, optional): Enables autocommits.
+
             results_type (str, optional): Determines the structure of the query results:
                 tuples, namedtuples, dicts.
+
             results_format (str, optional): Deprecated. This option has been renamed to
                 results_type.
 
@@ -468,10 +505,12 @@ class SingleStoreVectorStore(VectorStore):
         """Run images through the embeddings and add to the vectorstore.
 
         Args:
-            uris List[str]: File path to images.
+            uris (List[str]): File path to images.
                 Each URI will be added to the vectorstore as document content.
+
             metadatas (Optional[List[dict]], optional): Optional list of metadatas.
                 Defaults to None.
+
             embeddings (Optional[List[List[float]]], optional): Optional pre-generated
                 embeddings. Defaults to None.
 
@@ -499,8 +538,10 @@ class SingleStoreVectorStore(VectorStore):
 
         Args:
             texts (Iterable[str]): Iterable of strings/text to add to the vectorstore.
+
             metadatas (Optional[List[dict]], optional): Optional list of metadatas.
                 Defaults to None.
+
             embeddings (Optional[List[List[float]]], optional): Optional pre-generated
                 embeddings. Defaults to None.
 
@@ -616,6 +657,7 @@ class SingleStoreVectorStore(VectorStore):
         text_weight: float = 0.5,
         vector_weight: float = 0.5,
         vector_select_count_multiplier: int = 10,
+        full_text_scoring_mode: FullTextScoringMode = FullTextScoringMode.MATCH,
         **kwargs: Any,
     ) -> List[Document]:
         """Returns the most similar indexed documents to the query text.
@@ -624,7 +666,9 @@ class SingleStoreVectorStore(VectorStore):
 
         Args:
             query (str): The query text for which to find similar documents.
+
             k (int): The number of documents to return. Default is 4.
+
             filter (dict or FilterTypedDict, optional): A dictionary to filter by
                 metadata. Can be either:
 
@@ -638,30 +682,40 @@ class SingleStoreVectorStore(VectorStore):
                    - Logical: ``{"$and": [{...}, {...}]}``
 
                 Default is None.
+
             search_strategy (SearchStrategy): The search strategy to use.
                 Default is SearchStrategy.VECTOR_ONLY.
+
                 Available options are:
                 - SearchStrategy.VECTOR_ONLY: Searches only by vector similarity.
+
                 - SearchStrategy.TEXT_ONLY: Searches only by text similarity. This
                     option is only available if use_full_text_search is True.
+
                 - SearchStrategy.FILTER_BY_TEXT: Filters by text similarity and
                     searches by vector similarity. This option is only available if
                     use_full_text_search is True.
+
                 - SearchStrategy.FILTER_BY_VECTOR: Filters by vector similarity and
                     searches by text similarity. This option is only available if
                     use_full_text_search is True.
+
                 - SearchStrategy.WEIGHTED_SUM: Searches by a weighted sum of text and
                     vector similarity. This option is only available if
                     use_full_text_search is True and distance_strategy is DOT_PRODUCT.
+
             filter_threshold (float): The threshold for filtering by text or vector
                 similarity. Default is 0. This option has effect only if search_strategy
                 is SearchStrategy.FILTER_BY_TEXT or SearchStrategy.FILTER_BY_VECTOR.
+
             text_weight (float): The weight of text similarity in the weighted sum
                 search strategy. Default is 0.5. This option has effect only if
                 search_strategy is SearchStrategy.WEIGHTED_SUM.
+
             vector_weight (float): The weight of vector similarity in the weighted sum
                 search strategy. Default is 0.5. This option has effect only if
                 search_strategy is SearchStrategy.WEIGHTED_SUM.
+
             vector_select_count_multiplier (int): The multiplier for the number of
                 vectors to select when using the vector index. Default is 10.
                 This parameter has effect only if use_vector_index is True and
@@ -671,6 +725,28 @@ class SingleStoreVectorStore(VectorStore):
                 be k * vector_select_count_multiplier.
                 This is needed due to the limitations of the vector index.
 
+            full_text_scoring_mode (FullTextScoringMode): Specifies the algorithm
+                used to calculate text similarity scores. Defaults to
+                FullTextScoringMode.MATCH. This parameter only takes effect when
+                search_strategy is TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, or
+                WEIGHTED_SUM.
+
+                Available options:
+
+                - MATCH: Uses SingleStore's native MATCH() AGAINST() function.
+                    Returns a relevance score based on term frequency in the
+                    document. Compatible with both full-text index V1 and V2.
+
+                - BM25: Uses the BM25 (Best Matching 25) ranking algorithm.
+                    Provides more accurate relevance scoring by considering
+                    term frequency (TF), inverse document frequency (IDF), and
+                    document length normalization. Requires full-text index V2.
+
+                - BM25_GLOBAL: Similar to BM25, but computes IDF statistics
+                    across the entire dataset rather than per-partition. This
+                    can provide more consistent scoring in distributed
+                    environments but may have higher computational cost.
+                    Requires full-text index V2.
 
         Returns:
             List[Document]: A list of documents that are most similar to the query text.
@@ -720,11 +796,14 @@ class SingleStoreVectorStore(VectorStore):
                     host="username:password@localhost:3306/database",
                     use_full_text_search=True,
                     use_vector_index=True,
+                    full_text_index_version=FullTextIndexVersion.V2,
                 )
                 results = s2.similarity_search("query text", 1,
                     search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
                     text_weight=0.3,
-                    vector_weight=0.7)
+                    vector_weight=0.7,
+                    full_text_scoring_mode=FullTextScoringMode.BM25,
+                )
         """
         docs_and_scores = self.similarity_search_with_score(
             query=query,
@@ -735,6 +814,7 @@ class SingleStoreVectorStore(VectorStore):
             text_weight=text_weight,
             vector_weight=vector_weight,
             vector_select_count_multiplier=vector_select_count_multiplier,
+            full_text_scoring_mode=full_text_scoring_mode,
             **kwargs,
         )
         return [doc for doc, _ in docs_and_scores]
@@ -749,13 +829,16 @@ class SingleStoreVectorStore(VectorStore):
         text_weight: float = 0.5,
         vector_weight: float = 0.5,
         vector_select_count_multiplier: int = 10,
+        full_text_scoring_mode: FullTextScoringMode = FullTextScoringMode.MATCH,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to query. Uses cosine similarity.
 
         Args:
             query: Text to look up documents similar to.
+
             k: Number of Documents to return. Defaults to 4.
+
             filter: A dictionary to filter by metadata. Can be either:
 
                 1. Simple dict: ``{"field": "value", "status": "active"}``
@@ -768,30 +851,41 @@ class SingleStoreVectorStore(VectorStore):
                    - Logical: ``{"$and": [{...}, {...}]}``
 
                 Defaults to None.
+
             search_strategy (SearchStrategy): The search strategy to use.
                 Default is SearchStrategy.VECTOR_ONLY.
+
                 Available options are:
+
                 - SearchStrategy.VECTOR_ONLY: Searches only by vector similarity.
+
                 - SearchStrategy.TEXT_ONLY: Searches only by text similarity. This
                     option is only available if use_full_text_search is True.
+
                 - SearchStrategy.FILTER_BY_TEXT: Filters by text similarity and
                     searches by vector similarity. This option is only available if
                     use_full_text_search is True.
+
                 - SearchStrategy.FILTER_BY_VECTOR: Filters by vector similarity and
                     searches by text similarity. This option is only available if
                     use_full_text_search is True.
+
                 - SearchStrategy.WEIGHTED_SUM: Searches by a weighted sum of text and
                     vector similarity. This option is only available if
                     use_full_text_search is True and distance_strategy is DOT_PRODUCT.
+
             filter_threshold (float): The threshold for filtering by text or vector
                 similarity. Default is 0. This option has effect only if search_strategy
                 is SearchStrategy.FILTER_BY_TEXT or SearchStrategy.FILTER_BY_VECTOR.
+
             text_weight (float): The weight of text similarity in the weighted sum
                 search strategy. Default is 0.5. This option has effect only if
                 search_strategy is SearchStrategy.WEIGHTED_SUM.
+
             vector_weight (float): The weight of vector similarity in the weighted sum
                 search strategy. Default is 0.5. This option has effect only if
                 search_strategy is SearchStrategy.WEIGHTED_SUM.
+
             vector_select_count_multiplier (int): The multiplier for the number of
                 vectors to select when using the vector index. Default is 10.
                 This parameter has effect only if use_vector_index is True and
@@ -800,6 +894,30 @@ class SingleStoreVectorStore(VectorStore):
                 The number of vectors selected will
                 be k * vector_select_count_multiplier.
                 This is needed due to the limitations of the vector index.
+
+            full_text_scoring_mode (FullTextScoringMode): Specifies the algorithm
+                used to calculate text similarity scores. Defaults to
+                FullTextScoringMode.MATCH. This parameter only takes effect when
+                search_strategy is TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, or
+                WEIGHTED_SUM.
+
+                Available options:
+
+                - MATCH: Uses SingleStore's native MATCH() AGAINST() function.
+                    Returns a relevance score based on term frequency in the
+                    document. Compatible with both full-text index V1 and V2.
+
+                - BM25: Uses the BM25 (Best Matching 25) ranking algorithm.
+                    Provides more accurate relevance scoring by considering
+                    term frequency (TF), inverse document frequency (IDF), and
+                    document length normalization. Requires full-text index V2.
+
+                - BM25_GLOBAL: Similar to BM25, but computes IDF statistics
+                    across the entire dataset rather than per-partition. This
+                    can provide more consistent scoring in distributed
+                    environments but may have higher computational cost.
+                    Requires full-text index V2.
+
         Returns:
             List of Documents most similar to the query and score for each
             document.
@@ -836,10 +954,14 @@ class SingleStoreVectorStore(VectorStore):
                     host="username:password@localhost:3306/database",
                     use_full_text_search=True,
                     use_vector_index=True,
+                    full_text_index_version=FullTextIndexVersion.V2,
                 )
-                results = s2.similarity_search_with_score("query text", 1,
+                results = s2.similarity_search_with_score(
+                        "query text", 1,
                         search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
-                        filter_threshold=0.5)
+                        filter_threshold=0.5,
+                        full_text_scoring_mode=FullTextScoringMode.BM25,
+                )
 
             Weighted Sum Search Strategy:
             .. code-block:: python
@@ -854,10 +976,12 @@ class SingleStoreVectorStore(VectorStore):
                     use_full_text_search=True,
                     use_vector_index=True,
                 )
-                results = s2.similarity_search_with_score("query text", 1,
+                results = s2.similarity_search_with_score(
+                    "query text", 1,
                     search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
                     text_weight=0.3,
-                    vector_weight=0.7)
+                    vector_weight=0.7,
+                )
         """
 
         if (
@@ -1074,44 +1198,64 @@ class SingleStoreVectorStore(VectorStore):
         **kwargs: Any,
     ) -> SingleStoreVectorStore:
         """Create a SingleStoreVectorStore vectorstore from raw documents.
+
         This is a user-friendly interface that:
+
             1. Embeds documents.
+
             2. Creates a new table for the embeddings in SingleStoreVectorStore.
+
             3. Adds the documents to the newly created table.
+
         This is intended to be a quick way to get started.
         Args:
+
             texts (List[str]): List of texts to add to the vectorstore.
+
             embedding (Embeddings): A text embedding model.
+
             metadatas (Optional[List[dict]], optional): Optional list of metadatas.
                 Defaults to None.
+
             distance_strategy (DistanceStrategy, optional):
                 Determines the strategy employed for calculating
                 the distance between vectors in the embedding space.
                 Defaults to DOT_PRODUCT.
+
                 Available options are:
+
                 - DOT_PRODUCT: Computes the scalar product of two vectors.
                     This is the default behavior
+
                 - EUCLIDEAN_DISTANCE: Computes the Euclidean distance between
                     two vectors. This metric considers the geometric distance in
                     the vector space, and might be more suitable for embeddings
                     that rely on spatial relationships. This metric is not
                     compatible with the WEIGHTED_SUM search strategy.
+
             table_name (str, optional): Specifies the name of the table in use.
                 Defaults to "embeddings".
+
             content_field (str, optional): Specifies the field to store the content.
                 Defaults to "content".
+
             metadata_field (str, optional): Specifies the field to store metadata.
                 Defaults to "metadata".
+
             vector_field (str, optional): Specifies the field to store the vector.
                 Defaults to "vector".
+
             id_field (str, optional): Specifies the field to store the id.
                 Defaults to "id".
+
             use_vector_index (bool, optional): Toggles the use of a vector index.
                 Works only with SingleStore 8.5 or later. Defaults to False.
                 If set to True, vector_size parameter is required to be set to
                 a proper value.
+
             vector_index_name (str, optional): Specifies the name of the vector index.
                 Defaults to empty. Will be ignored if use_vector_index is set to False.
+
             vector_index_options (dict, optional): Specifies the options for
                 the vector index. Defaults to {}.
                 Will be ignored if use_vector_index is set to False. The options are:
@@ -1119,10 +1263,12 @@ class SingleStoreVectorStore(VectorStore):
                     Defaults to IVF_PQFS.
                 For more options, please refer to the SingleStore documentation:
                 https://docs.singlestore.com/cloud/reference/sql-reference/vector-functions/vector-indexing/
+
             vector_size (int, optional): Specifies the size of the vector.
                 Defaults to 1536. Required if use_vector_index is set to True.
                 Should be set to the same value as the size of the vectors
                 stored in the vector_field.
+
             use_full_text_search (bool, optional): Toggles the use a full-text index
                 on the document content. Defaults to False. If set to True, the table
                 will be created with a full-text index on the content field,
@@ -1130,13 +1276,17 @@ class SingleStoreVectorStore(VectorStore):
                 FILTER_BY_TEXT, FILTER_BY_VECTOR, and WEIGHTED_SUM search strategies.
                 If set to False, the similarity_search method will only allow
                 VECTOR_ONLY search strategy.
+
             full_text_index_version (FullTextIndexVersion, optional): Determines the
                 version of the full-text index to use. Defaults to V1.
+
                 Available options are:
+
                 - V1: Uses the original full-text index implementation. This version
                     is compatible with all versions of SingleStore, but does not
                     support some of the advanced features of the full-text search,
                     such as boolean mode and query expansion.
+
                 - V2: Uses the new full-text index implementation introduced in
                     SingleStore 8.7. This version offers improved performance and
                     additional features, but is only compatible with SingleStore 8.7
@@ -1146,36 +1296,53 @@ class SingleStoreVectorStore(VectorStore):
 
             pool_size (int, optional): Determines the number of active connections in
                 the pool. Defaults to 5.
+
             max_overflow (int, optional): Determines the maximum number of connections
                 allowed beyond the pool_size. Defaults to 10.
+
             timeout (float, optional): Specifies the maximum wait time in seconds for
                 establishing a connection. Defaults to 30.
+
 
             Additional optional arguments provide further customization over the
             database connection:
 
             pure_python (bool, optional): Toggles the connector mode. If True,
                 operates in pure Python mode.
+
             local_infile (bool, optional): Allows local file uploads.
+
             charset (str, optional): Specifies the character set for string values.
+
             ssl_key (str, optional): Specifies the path of the file containing the SSL
                 key.
+
             ssl_cert (str, optional): Specifies the path of the file containing the SSL
                 certificate.
+
             ssl_ca (str, optional): Specifies the path of the file containing the SSL
                 certificate authority.
+
             ssl_cipher (str, optional): Sets the SSL cipher list.
+
             ssl_disabled (bool, optional): Disables SSL usage.
+
             ssl_verify_cert (bool, optional): Verifies the server's certificate.
                 Automatically enabled if ``ssl_ca`` is specified.
+
             ssl_verify_identity (bool, optional): Verifies the server's identity.
+
             conv (dict[int, Callable], optional): A dictionary of data conversion
                 functions.
+
             credential_type (str, optional): Specifies the type of authentication to
                 use: auth.PASSWORD, auth.JWT, or auth.BROWSER_SSO.
+
             autocommit (bool, optional): Enables autocommits.
+
             results_type (str, optional): Determines the structure of the query results:
                 tuples, namedtuples, dicts.
+
             results_format (str, optional): Deprecated. This option has been renamed to
                 results_type.
 

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -1022,7 +1022,8 @@ class SingleStoreVectorStore(VectorStore):
             )
 
         if (
-            full_text_scoring_mode != FullTextScoringMode.MATCH
+            search_strategy != SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY
+            and full_text_scoring_mode != FullTextScoringMode.MATCH
             and self.full_text_index_version != FullTextIndexVersion.V2
         ):
             raise ValueError(

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -198,6 +198,54 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
             ),
         ]
 
+    @pytest.fixture()
+    def korean_docs(self) -> List[Document]:
+        return [
+            Document(
+                page_content="""가뭄이 든 사막에 갑작스러운
+                    폭우가 찾아와 안도감을 선사했습니다.
+                    메마른 땅 위로 빗방울이 춤을 추듯 떨어지며,
+                    대지는 감미로운 흙 내음을 풍기며 활력을
+                    되찾았습니다.""",
+                metadata={"category": "비"},
+            ),
+            Document(
+                page_content="""번화한 도시 한복판에서 비가
+                    끊임없이 쏟아졌습니다. 보도에 부딪히는 빗소리가
+                    교향곡처럼 울려 퍼졌고, 회색빛 도심 속에는
+                    알록달록한 우산들이 마치 꽃처럼 피어났습니다.""",
+                metadata={"category": "비"},
+            ),
+            Document(
+                page_content="""높은 산맥 위로 비가 부드러운
+                    안개로 변해 봉우리들을 신비로운 베일로 감싸 안았습니다.
+                    빗방울 하나하나가 아래에 놓인 고대의 바위들에게 비밀을
+                    속삭이는 듯했습니다.""",
+                metadata={"category": "비"},
+            ),
+            Document(
+                page_content="""눈이 시골 풍경을 하얗고 깨끗하게
+                    덮으며 평온한 장면을 연출했습니다. 나뭇가지마다 내려앉은
+                    섬세한 눈송이들은 마치 자연이 만든 레이스 같았고,
+                    세상은 고요한 정적 속에 잠겼습니다.""",
+                metadata={"category": "눈"},
+            ),
+            Document(
+                page_content="""도심 속으로 눈이 내리며 번잡했던
+                    거리들이 겨울의 동화 속 나라로 변했습니다. 흩날리는
+                    눈발 사이로 눈싸움을 하는 아이들의 웃음소리가 울려
+                    퍼졌고, 연말의 전등불은 반짝였습니다.""",
+                metadata={"category": "눈"},
+            ),
+            Document(
+                page_content="""험준한 산봉우리 위로 눈이 거세게
+                    쏟아지며 대지를 순백의 알프스 낙원으로 빚어냈습니다.
+                    얼어붙은 결정체들이 달빛 아래 영롱하게 빛나며, 아래에
+                    펼쳐진 황야에 마법 같은 황홀함을 선사했습니다.""",
+                metadata={"category": "눈"},
+            ),
+        ]
+
     @pytest.mark.xfail(reason="id should be integer")
     def test_add_documents_with_existing_ids(self, vectorstore: VectorStore) -> None:
         """Test that add_documents with existing IDs is idempotent.
@@ -943,8 +991,19 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
         finally:
             docsearch.drop()
 
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
     def test_fulltext_search_korean(
-        self, clean_db_connection_parameters: ConnectionParameters
+        self,
+        korean_docs: List[Document],
+        full_text_scoring_mode: FullTextScoringMode,
+        clean_db_connection_parameters: ConnectionParameters,
     ) -> None:
         """Test that full-text search works with Korean text."""
         docsearch = SingleStoreVectorStore(
@@ -958,56 +1017,90 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
             full_text_index_version=FullTextIndexVersion.V2,
         )
         try:
-            docs = [
-                Document(
-                    page_content="""가뭄이 든 사막에 갑작스러운
-                    폭우가 찾아와 안도감을 선사했습니다.
-                    메마른 땅 위로 빗방울이 춤을 추듯 떨어지며,
-                    대지는 감미로운 흙 내음을 풍기며 활력을
-                    되찾았습니다.""",
-                    metadata={"category": "비"},
-                ),
-                Document(
-                    page_content="""번화한 도시 한복판에서 비가
-                    끊임없이 쏟아졌습니다. 보도에 부딪히는 빗소리가
-                    교향곡처럼 울려 퍼졌고, 회색빛 도심 속에는
-                    알록달록한 우산들이 마치 꽃처럼 피어났습니다.""",
-                    metadata={"category": "비"},
-                ),
-                Document(
-                    page_content="""높은 산맥 위로 비가 부드러운
-                    안개로 변해 봉우리들을 신비로운 베일로 감싸 안았습니다.
-                    빗방울 하나하나가 아래에 놓인 고대의 바위들에게 비밀을
-                    속삭이는 듯했습니다.""",
-                    metadata={"category": "비"},
-                ),
-                Document(
-                    page_content="""눈이 시골 풍경을 하얗고 깨끗하게
-                    덮으며 평온한 장면을 연출했습니다. 나뭇가지마다 내려앉은
-                    섬세한 눈송이들은 마치 자연이 만든 레이스 같았고,
-                    세상은 고요한 정적 속에 잠겼습니다.""",
-                    metadata={"category": "눈"},
-                ),
-                Document(
-                    page_content="""도심 속으로 눈이 내리며 번잡했던
-                    거리들이 겨울의 동화 속 나라로 변했습니다. 흩날리는
-                    눈발 사이로 눈싸움을 하는 아이들의 웃음소리가 울려
-                    퍼졌고, 연말의 전등불은 반짝였습니다.""",
-                    metadata={"category": "눈"},
-                ),
-                Document(
-                    page_content="""험준한 산봉우리 위로 눈이 거세게
-                    쏟아지며 대지를 순백의 알프스 낙원으로 빚어냈습니다.
-                    얼어붙은 결정체들이 달빛 아래 영롱하게 빛나며, 아래에
-                    펼쳐진 황야에 마법 같은 황홀함을 선사했습니다.""",
-                    metadata={"category": "눈"},
-                ),
-            ]
-            docsearch.add_documents(docs)
+            docsearch.add_documents(korean_docs)
             textResults = docsearch.similarity_search(
                 "메마른 사막의 폭우, 비",
                 k=1,
                 search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(textResults) == 1
+            assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content
+        finally:
+            docsearch.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_filter_by_vector_korean(
+        self,
+        korean_docs: List[Document],
+        full_text_scoring_mode: FullTextScoringMode,
+        clean_db_connection_parameters: ConnectionParameters,
+    ) -> None:
+        """Test that filtering by vector works with Korean text."""
+        docsearch = SingleStoreVectorStore(
+            embedding=IncrementalEmbeddings(),
+            host=clean_db_connection_parameters.Host,
+            port=clean_db_connection_parameters.Port,
+            user=clean_db_connection_parameters.User,
+            password=clean_db_connection_parameters.Password,
+            database=clean_db_connection_parameters.Database,
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+        )
+        try:
+            docsearch.add_documents(korean_docs)
+            textResults = docsearch.similarity_search(
+                "메마른 사막의 폭우, 비",
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
+                filter_threshold=-10.0,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(textResults) == 1
+            assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content
+        finally:
+            docsearch.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_filter_by_text_korean(
+        self,
+        korean_docs: List[Document],
+        full_text_scoring_mode: FullTextScoringMode,
+        clean_db_connection_parameters: ConnectionParameters,
+    ) -> None:
+        """Test that filtering by text works with Korean text."""
+        docsearch = SingleStoreVectorStore(
+            embedding=IncrementalEmbeddings(),
+            host=clean_db_connection_parameters.Host,
+            port=clean_db_connection_parameters.Port,
+            user=clean_db_connection_parameters.User,
+            password=clean_db_connection_parameters.Password,
+            database=clean_db_connection_parameters.Database,
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+        )
+        try:
+            docsearch.add_documents(korean_docs)
+            textResults = docsearch.similarity_search(
+                "메마른 사막의 폭우, 비",
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
+                filter_threshold=0.2,
+                full_text_scoring_mode=full_text_scoring_mode,
             )
             assert len(textResults) == 1
             assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -11,7 +11,11 @@ from langchain_core.vectorstores import VectorStore
 from langchain_experimental.open_clip import OpenCLIPEmbeddings
 from langchain_tests.integration_tests import VectorStoreIntegrationTests
 
-from langchain_singlestore._utils import DistanceStrategy, FullTextIndexVersion
+from langchain_singlestore._utils import (
+    DistanceStrategy,
+    FullTextIndexVersion,
+    FullTextScoringMode,
+)
 from langchain_singlestore.vectorstores import SingleStoreVectorStore
 from tests.integration_tests.conftest import TEST_DB_NAME, ConnectionParameters
 
@@ -901,6 +905,41 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
                     assert "FULLTEXT USING VERSION 2" in create_table_sql
                 else:
                     raise ValueError("Unexpected full text index version")
+        finally:
+            docsearch.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [FullTextScoringMode.BM25, FullTextScoringMode.BM25_GLOBAL],
+    )
+    def test_fulltext_search_v1_unsupported(
+        self,
+        full_text_scoring_mode: FullTextScoringMode,
+        clean_db_connection_parameters: ConnectionParameters,
+    ) -> None:
+        """Test that using unsupported full-text search version raises error."""
+        docsearch = SingleStoreVectorStore(
+            embedding=IncrementalEmbeddings(),
+            host=clean_db_connection_parameters.Host,
+            port=clean_db_connection_parameters.Port,
+            user=clean_db_connection_parameters.User,
+            password=clean_db_connection_parameters.Password,
+            database=clean_db_connection_parameters.Database,
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V1,
+        )
+        try:
+            with pytest.raises(ValueError) as exc_info:
+                docsearch.similarity_search(
+                    "test",
+                    k=1,
+                    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+                    full_text_scoring_mode=full_text_scoring_mode,
+                )
+            assert (
+                "is not supported with full-text index version FullTextIndexVersion.V1"
+                in str(exc_info.value)
+            )
         finally:
             docsearch.drop()
 

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -1018,14 +1018,14 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
         )
         try:
             docsearch.add_documents(korean_docs)
-            textResults = docsearch.similarity_search(
+            text_results = docsearch.similarity_search(
                 "메마른 사막의 폭우, 비",
                 k=1,
                 search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
                 full_text_scoring_mode=full_text_scoring_mode,
             )
-            assert len(textResults) == 1
-            assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content
+            assert len(text_results) == 1
+            assert "가뭄이 든 사막에 갑작스러운" in text_results[0].page_content
         finally:
             docsearch.drop()
 

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -1056,15 +1056,15 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
         )
         try:
             docsearch.add_documents(korean_docs)
-            textResults = docsearch.similarity_search(
+            text_results = docsearch.similarity_search(
                 "메마른 사막의 폭우, 비",
                 k=1,
                 search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
                 filter_threshold=-10.0,
                 full_text_scoring_mode=full_text_scoring_mode,
             )
-            assert len(textResults) == 1
-            assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content
+            assert len(text_results) == 1
+            assert "가뭄이 든 사막에 갑작스러운" in text_results[0].page_content
         finally:
             docsearch.drop()
 
@@ -1095,14 +1095,14 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
         )
         try:
             docsearch.add_documents(korean_docs)
-            textResults = docsearch.similarity_search(
+            text_results = docsearch.similarity_search(
                 "메마른 사막의 폭우, 비",
                 k=1,
                 search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
                 filter_threshold=0.2,
                 full_text_scoring_mode=full_text_scoring_mode,
             )
-            assert len(textResults) == 1
-            assert "가뭄이 든 사막에 갑작스러운" in textResults[0].page_content
+            assert len(text_results) == 1
+            assert "가뭄이 든 사막에 갑작스러운" in text_results[0].page_content
         finally:
             docsearch.drop()

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -866,6 +866,44 @@ class TestSingleStoreVectorStore(VectorStoreIntegrationTests):
             else:
                 raise ValueError("Unexpected full text index version")
 
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_fulltext_index_version_creation_from_texts(
+        self,
+        clean_db_connection_parameters: ConnectionParameters,
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test that full-text index is created when use_full_text_search is True."""
+        docsearch = SingleStoreVectorStore.from_texts(
+            ["test"],
+            embedding=IncrementalEmbeddings(),
+            host=clean_db_connection_parameters.Host,
+            port=clean_db_connection_parameters.Port,
+            user=clean_db_connection_parameters.User,
+            password=clean_db_connection_parameters.Password,
+            database=clean_db_connection_parameters.Database,
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+        )
+        try:
+            conn = docsearch._get_connection()
+
+            with conn.cursor() as cur:
+                cur.execute("SHOW CREATE TABLE embeddings")
+                result = cur.fetchone()
+                assert result is not None
+                create_table_sql = result[1]  # The second column contains the SQL
+                if full_text_index_version == FullTextIndexVersion.V1:
+                    assert "FULLTEXT USING VERSION 1" in create_table_sql
+                elif full_text_index_version == FullTextIndexVersion.V2:
+                    assert "FULLTEXT USING VERSION 2" in create_table_sql
+                else:
+                    raise ValueError("Unexpected full text index version")
+        finally:
+            docsearch.drop()
+
     def test_fulltext_search_korean(
         self, clean_db_connection_parameters: ConnectionParameters
     ) -> None:

--- a/tests/unit_tests/test_vectorstores.py
+++ b/tests/unit_tests/test_vectorstores.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 
 from langchain_core.embeddings import Embeddings
 
-from langchain_singlestore._utils import DistanceStrategy
+from langchain_singlestore._utils import (
+    DistanceStrategy,
+    FullTextIndexVersion,
+    FullTextScoringMode,
+)
 from langchain_singlestore.vectorstores import SingleStoreVectorStore
 
 
@@ -243,6 +247,144 @@ class TestSingleStoreVectorStoreEmbeddings(unittest.TestCase):
         vs = SingleStoreVectorStore(embedding=embeddings, host="localhost")
 
         assert vs.embeddings is embeddings
+
+
+class TestFulltextScoringModeToSql(unittest.TestCase):
+    """Test _fulltext_scoring_mode_to_sql method."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.patcher = patch("langchain_singlestore.vectorstores.QueuePool")
+        self.mock_pool_class = self.patcher.start()
+        self.mock_pool = MagicMock()
+        self.mock_pool_class.return_value = self.mock_pool
+
+    def tearDown(self) -> None:
+        """Clean up patches."""
+        self.patcher.stop()
+
+    def test_match_mode_with_v1_index(self) -> None:
+        """Test MATCH mode with full-text index V1."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V1,
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.MATCH, "test query"
+        )
+
+        assert sql == "MATCH (content) AGAINST (%s)"
+        assert query == "test query"
+
+    def test_match_mode_with_v2_index(self) -> None:
+        """Test MATCH mode with full-text index V2 uses TABLE syntax."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.MATCH, "test query"
+        )
+
+        assert sql == "MATCH (TABLE embeddings) AGAINST (%s)"
+        assert query == "content:(test query)"
+
+    def test_bm25_mode_with_v2_index(self) -> None:
+        """Test BM25 mode with full-text index V2."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.BM25, "test query"
+        )
+
+        assert sql == "BM25(embeddings, %s)"
+        assert query == "content:(test query)"
+
+    def test_bm25_global_mode_with_v2_index(self) -> None:
+        """Test BM25_GLOBAL mode with full-text index V2."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.BM25_GLOBAL, "test query"
+        )
+
+        assert sql == "BM25_GLOBAL(embeddings, %s)"
+        assert query == "content:(test query)"
+
+    def test_custom_content_field_with_v1(self) -> None:
+        """Test that custom content field is used in SQL with V1."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V1,
+            content_field="text_content",
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.MATCH, "search terms"
+        )
+
+        assert sql == "MATCH (text_content) AGAINST (%s)"
+        assert query == "search terms"
+
+    def test_custom_content_field_with_v2_match(self) -> None:
+        """Test custom content field with V2 and MATCH mode."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            content_field="text_content",
+            table_name="my_docs",
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.MATCH, "search terms"
+        )
+
+        assert sql == "MATCH (TABLE my_docs) AGAINST (%s)"
+        assert query == "text_content:(search terms)"
+
+    def test_custom_content_field_with_v2_bm25(self) -> None:
+        """Test custom content field with V2 and BM25 mode."""
+        embeddings = MockEmbeddings()
+        vs = SingleStoreVectorStore(
+            embedding=embeddings,
+            host="localhost",
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            content_field="text_content",
+        )
+
+        sql, query = vs._fulltext_scoring_mode_to_sql(
+            FullTextScoringMode.BM25, "search terms"
+        )
+
+        assert sql == "BM25(embeddings, %s)"
+        assert query == "text_content:(search terms)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added support of different fulltext scoring methods:
  - MATCH - default one
  - BM25
  - BM25_GLOBAL
- Updated tests and README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes SQL generation and validation for non-vector-only search paths, which could affect ranking behavior and compatibility across SingleStore versions.
> 
> **Overview**
> **Adds full-text scoring mode support to the vector store.** `SingleStoreVectorStore.similarity_search*` now accepts `full_text_scoring_mode` and can rank text queries using `MATCH` (default), `BM25`, or `BM25_GLOBAL`, with guardrails to reject BM25 modes unless `FullTextIndexVersion.V2` is used.
> 
> **Refactors and exposes the new API surface.** Introduces `FullTextScoringMode` in `_utils`, exports it (along with `DistanceStrategy`/`FullTextIndexVersion`) from `langchain_singlestore.__init__`, centralizes full-text SQL generation via `_fulltext_scoring_mode_to_sql`, and updates README/examples/import paths plus unit/integration tests (including Korean-text cases and V1 unsupported assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee4a42076dd6c8d635444d54254780c7706a070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->