### PR TITLE
Add pre-computed embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This package includes the following components:
 The `SingleStoreChatMessageHistory` class provides persistent storage for chat message history in SingleStore. This is essential for AI applications that need to maintain conversation context across sessions. It seamlessly integrates with LangChain's chat models and chains.
 
 **Key Features:**
+
 - Automatic schema creation and management
 - Support for multiple conversation sessions
 - Efficient message retrieval and storage
@@ -29,6 +30,7 @@ The `SingleStoreChatMessageHistory` class provides persistent storage for chat m
 The `SingleStoreSemanticCache` class implements semantic caching for LLM responses using SingleStore's vector capabilities. Instead of exact string matching, it uses embeddings to find semantically similar cached queries, dramatically reducing API costs and improving performance for similar questions.
 
 **Key Features:**
+
 - Vector-based semantic similarity for cache hits
 - Reduces LLM API calls for similar queries
 - Configurable similarity threshold
@@ -39,6 +41,7 @@ The `SingleStoreSemanticCache` class implements semantic caching for LLM respons
 The `SingleStoreVectorStore` class provides a powerful document storage and retrieval system with combined vector and full-text search capabilities. It supports multiple search strategies, advanced metadata filtering, and both vector and text-based indexing for optimal performance.
 
 **Key Features:**
+
 - Hybrid search combining vector and text indexes
 - Multiple search strategies (VECTOR_ONLY, TEXT_ONLY, FILTER_BY_TEXT, FILTER_BY_VECTOR, WEIGHTED_SUM)
 - Simple and advanced metadata filtering
@@ -46,12 +49,14 @@ The `SingleStoreVectorStore` class provides a powerful document storage and retr
 - Configurable distance metrics (DOT_PRODUCT, EUCLIDEAN_DISTANCE)
 - Full-text index versions (V1, V2) with different capabilities
 - Multiple text scoring algorithms (MATCH, BM25, BM25_GLOBAL)
+- Pre-computed embeddings support for texts, documents, images, and queries
 
 ### SQL Database Retriever
 
 The `SingleStoreSQLDatabaseRetriever` enables LangChain agents and chains to execute SQL queries directly against SingleStore and retrieve results as structured documents.
 
 **Key Features:**
+
 - Execute SQL queries and convert results to documents
 - Flexible row-to-document conversion with custom handlers
 - Connection pooling for efficient resource management
@@ -320,15 +325,183 @@ results = vector_store.similarity_search(
 | BM25_GLOBAL | BM25 with global IDF statistics | V2 only | Consistent scoring in distributed/sharded environments |
 
 **When to use each mode:**
+
 - **MATCH**: Default mode. Fast, simple keyword matching. Good for basic search needs.
 - **BM25**: Better relevance ranking by considering term frequency, inverse document frequency, and document length. Recommended for most text search applications.
 - **BM25_GLOBAL**: Same as BM25 but calculates statistics globally across all partitions. Use when you need consistent scoring across a distributed SingleStore cluster.
+
+#### Pre-computed Embeddings
+
+SingleStoreVectorStore supports using pre-computed embeddings instead of generating them at runtime. This is useful when:
+
+- You have embeddings from a different source or model
+- You want to avoid repeated embedding API calls
+- You're migrating data from another vector store
+- You need to use custom or fine-tuned embedding models outside LangChain
+
+**Adding Texts with Pre-computed Embeddings:**
+
+```python
+from langchain_singlestore import SingleStoreVectorStore
+
+# Initialize vector store (embedding model still needed for the interface)
+vector_store = SingleStoreVectorStore(
+    embedding=some_embedding_model,
+    host="127.0.0.1:3306/db",
+)
+
+# Your pre-computed embeddings (e.g., from a batch processing job)
+texts = [
+    "The Eiffel Tower is in Paris.",
+    "Big Ben is in London.",
+    "The Colosseum is in Rome.",
+]
+precomputed_embeddings = [
+    [0.1, 0.2, 0.3, ...],  # embedding for text 1
+    [0.4, 0.5, 0.6, ...],  # embedding for text 2
+    [0.7, 0.8, 0.9, ...],  # embedding for text 3
+]
+metadatas = [
+    {"city": "Paris"},
+    {"city": "London"},
+    {"city": "Rome"},
+]
+
+# Add texts with pre-computed embeddings (bypasses the embedding model)
+ids = vector_store.add_texts(
+    texts=texts,
+    metadatas=metadatas,
+    embeddings=precomputed_embeddings,  # Pre-computed embeddings
+)
+```
+
+**Adding Documents with Pre-computed Embeddings:**
+
+```python
+from langchain_core.documents import Document
+
+documents = [
+    Document(page_content="The Eiffel Tower is in Paris.", metadata={"city": "Paris"}),
+    Document(page_content="Big Ben is in London.", metadata={"city": "London"}),
+    Document(page_content="The Colosseum is in Rome.", metadata={"city": "Rome"}),
+]
+precomputed_embeddings = [
+    [0.1, 0.2, 0.3, ...],
+    [0.4, 0.5, 0.6, ...],
+    [0.7, 0.8, 0.9, ...],
+]
+
+# Add documents with pre-computed embeddings
+ids = vector_store.add_documents(
+    documents=documents,
+    embeddings=precomputed_embeddings,
+)
+```
+
+**Adding Images with Pre-computed Embeddings:**
+
+```python
+image_uris = [
+    "path/to/image1.jpg",
+    "path/to/image2.jpg",
+    "path/to/image3.jpg",
+]
+precomputed_image_embeddings = [
+    [0.1, 0.2, 0.3, ...],  # embedding for image 1
+    [0.4, 0.5, 0.6, ...],  # embedding for image 2
+    [0.7, 0.8, 0.9, ...],  # embedding for image 3
+]
+
+# Add images with pre-computed embeddings
+ids = vector_store.add_images(
+    uris=image_uris,
+    embeddings=precomputed_image_embeddings,
+)
+```
+
+**Similarity Search with Pre-computed Query Embedding:**
+
+```python
+# Your pre-computed query embedding
+query_embedding = [0.15, 0.25, 0.35, ...]
+
+# Search using pre-computed query embedding (bypasses embed_query)
+results = vector_store.similarity_search(
+    query="landmarks",  # Query text (used for full-text search strategies)
+    k=5,
+    query_embedding=query_embedding,  # Pre-computed embedding for vector search
+)
+
+# Also works with similarity_search_with_score
+results_with_scores = vector_store.similarity_search_with_score(
+    query="landmarks",
+    k=5,
+    query_embedding=query_embedding,
+)
+```
+
+**Using from_texts with Pre-computed Embeddings:**
+
+```python
+# Create vector store and add texts in one step with pre-computed embeddings
+vector_store = SingleStoreVectorStore.from_texts(
+    texts=texts,
+    embedding=some_embedding_model,  # Required for interface, but won't be called
+    metadatas=metadatas,
+    embeddings=precomputed_embeddings,  # Pre-computed embeddings
+    host="127.0.0.1:3306/db",
+)
+```
+
+**Using from_documents with Pre-computed Embeddings:**
+
+```python
+# Create vector store and add documents in one step with pre-computed embeddings
+vector_store = SingleStoreVectorStore.from_documents(
+    documents=documents,
+    embedding=some_embedding_model,  # Required for interface, but won't be called
+    embeddings=precomputed_embeddings,  # Pre-computed embeddings
+    host="127.0.0.1:3306/db",
+)
+```
+
+**Combined with Search Strategies:**
+
+Pre-computed embeddings work with all search strategies:
+
+```python
+# VECTOR_ONLY with pre-computed query embedding
+results = vector_store.similarity_search(
+    query="landmarks",
+    k=5,
+    query_embedding=query_embedding,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY,
+)
+
+# TEXT_ONLY doesn't use query embedding (pure full-text search)
+results = vector_store.similarity_search(
+    query="Eiffel Tower Paris",
+    k=5,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+)
+
+# WEIGHTED_SUM with pre-computed query embedding
+results = vector_store.similarity_search(
+    query="famous landmarks",
+    k=5,
+    query_embedding=query_embedding,
+    search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+    text_weight=0.3,
+    vector_weight=0.7,
+)
+```
 
 ### Document Loader
 
 The `SingleStoreLoader` class provides efficient loading of documents directly from SingleStore database tables. This is ideal for applications that need to process documents stored in your database without intermediate file exports, enabling seamless ETL workflows.
 
 **Key Features:**
+
 - Load documents from any database table
 - Configurable content and metadata fields
 - Efficient batch processing
@@ -367,6 +540,7 @@ vector_store.add_documents(chunked_docs)
 The `SingleStoreSQLDatabaseRetriever` enables LangChain agents and chains to execute SQL queries directly against a SingleStore database and retrieve results formatted as documents. This is perfect for building database-aware AI applications that need to query structured data.
 
 **Key Features:**
+
 - Execute SQL queries and retrieve results as documents
 - Flexible row-to-document conversion with custom handlers
 - Connection pooling for efficient resource management

--- a/README.md
+++ b/README.md
@@ -386,9 +386,9 @@ documents = [
     Document(page_content="The Colosseum is in Rome.", metadata={"city": "Rome"}),
 ]
 precomputed_embeddings = [
-    [0.1, 0.2, 0.3, ...],
-    [0.4, 0.5, 0.6, ...],
-    [0.7, 0.8, 0.9, ...],
+    [0.1, 0.2, 0.3, 0.4],
+    [0.4, 0.5, 0.6, 0.7],
+    [0.7, 0.8, 0.9, 1.0],
 ]
 
 # Add documents with pre-computed embeddings
@@ -407,9 +407,9 @@ image_uris = [
     "path/to/image3.jpg",
 ]
 precomputed_image_embeddings = [
-    [0.1, 0.2, 0.3, ...],  # embedding for image 1
-    [0.4, 0.5, 0.6, ...],  # embedding for image 2
-    [0.7, 0.8, 0.9, ...],  # embedding for image 3
+    [0.1, 0.2, 0.3, 0.4],  # embedding for image 1
+    [0.4, 0.5, 0.6, 0.7],  # embedding for image 2
+    [0.7, 0.8, 0.9, 1.0],  # embedding for image 3
 ]
 
 # Add images with pre-computed embeddings
@@ -423,7 +423,7 @@ ids = vector_store.add_images(
 
 ```python
 # Your pre-computed query embedding
-query_embedding = [0.15, 0.25, 0.35, ...]
+query_embedding = [0.15, 0.25, 0.35, 0.45]
 
 # Search using pre-computed query embedding (bypasses embed_query)
 results = vector_store.similarity_search(

--- a/README.md
+++ b/README.md
@@ -357,9 +357,9 @@ texts = [
     "The Colosseum is in Rome.",
 ]
 precomputed_embeddings = [
-    [0.1, 0.2, 0.3, ...],  # embedding for text 1
-    [0.4, 0.5, 0.6, ...],  # embedding for text 2
-    [0.7, 0.8, 0.9, ...],  # embedding for text 3
+    [0.1, 0.2, 0.3, 0.4],  # embedding for text 1
+    [0.4, 0.5, 0.6, 0.7],  # embedding for text 2
+    [0.7, 0.8, 0.9, 1.0],  # embedding for text 3
 ]
 metadatas = [
     {"city": "Paris"},

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -522,6 +522,19 @@ class SingleStoreVectorStore(VectorStore):
         Returns:
             List[str]: list of document ids added to the vectorstore
         """
+
+        if embeddings is not None and len(embeddings) != len(uris):
+            raise ValueError("Length of embeddings must match length of uris")
+
+        if (
+            embeddings is not None
+            and self.use_vector_index
+            and len(embeddings[0]) != self.vector_size
+        ):
+            raise ValueError(
+                "Pre-computed embedding size does not match the specified vector_size"
+            )
+
         # Set embeddings
         if (
             embeddings is None

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -565,14 +565,35 @@ class SingleStoreVectorStore(VectorStore):
 
         Returns:
             List[str]: list of document ids added to the vectorstore
+
+        Raises:
+            ValueError: If embeddings list length doesn't match texts count,
+                or if embedding vector size doesn't match vector_size when using
+                vector index.
         """
+        # Convert texts to list for length validation and iteration
+        texts_list = list(texts)
+
+        if embeddings is not None and len(embeddings) != len(texts_list):
+            raise ValueError("The number of embeddings must match the number of texts")
+
+        if (
+            embeddings is not None
+            and self.use_vector_index
+            and len(embeddings) > 0
+            and len(embeddings[0]) != self.vector_size
+        ):
+            raise ValueError(
+                "Pre-computed embedding size does not match the specified vector_size"
+            )
+
         result_ids: List[str] = []
         conn = self.connection_pool.connect()
         try:
             cur = conn.cursor()
             try:
                 # Write data to singlestore db
-                for i, text in enumerate(texts):
+                for i, text in enumerate(texts_list):
                     # Use provided values by default or fallback
                     metadata = metadatas[i] if metadatas else {}
                     embedding = (

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -576,37 +576,33 @@ class SingleStoreVectorStore(VectorStore):
                 or if embedding vector size doesn't match vector_size when using
                 vector index.
         """
-        texts_list = []
 
-        if embeddings is not None:
-            texts_list = list(texts)
-            if len(embeddings) != len(texts_list):
-                raise ValueError(
-                    "The number of embeddings must match the number of texts"
-                )
-            elif self.use_vector_index and len(embeddings) > 0:
-                if any(
-                    len(embedding_vector) != self.vector_size
-                    for embedding_vector in embeddings
-                ):
-                    raise ValueError(
-                        "Pre-computed embedding size does not match the vector_size"
-                    )
-
+        text_count = 0
         result_ids: List[str] = []
         conn = self.connection_pool.connect()
         try:
             cur = conn.cursor()
             try:
                 # Write data to singlestore db
-                for i, text in enumerate(texts if len(texts_list) == 0 else texts_list):
+                for i, text in enumerate(texts):
+                    text_count += 1
                     # Use provided values by default or fallback
                     metadata = metadatas[i] if metadatas else {}
+                    if embeddings is not None and len(embeddings) <= i:
+                        raise ValueError(
+                            "The number of embeddings must match the number of texts"
+                        )
                     embedding = (
                         embeddings[i]
                         if embeddings
                         else self.embedding.embed_documents([text])[0]
                     )
+                    if self.use_vector_index and (
+                        not embedding or len(embedding) != self.vector_size
+                    ):
+                        raise ValueError(
+                            "Embedding size does not match the vector_size"
+                        )
                     if not ids or len(ids) <= i:
                         cur.execute(
                             """INSERT INTO {}({}, {}, {})
@@ -656,6 +652,10 @@ class SingleStoreVectorStore(VectorStore):
                         result_ids.append(ids[i])
                 if self.use_vector_index or self.use_full_text_search:
                     cur.execute("OPTIMIZE TABLE {} FLUSH;".format(self.table_name))
+                if embeddings is not None and len(embeddings) != text_count:
+                    raise ValueError(
+                        "The number of embeddings must match the number of texts"
+                    )
             finally:
                 cur.close()
         finally:

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -690,7 +690,7 @@ class SingleStoreVectorStore(VectorStore):
                 Default is None.
 
             query_embedding (List[float], optional): Pre-computed embedding for
-                the query.cIf not provided, the embedding will be computed using
+                the query. If not provided, the embedding will be computed using
                 the configured embedding function.
 
             search_strategy (SearchStrategy): The search strategy to use.

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -656,6 +656,7 @@ class SingleStoreVectorStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Union[dict, FilterTypedDict]] = None,
+        query_embedding: Optional[List[float]] = None,
         search_strategy: SearchStrategy = SearchStrategy.VECTOR_ONLY,
         filter_threshold: float = 0,
         text_weight: float = 0.5,
@@ -687,6 +688,10 @@ class SingleStoreVectorStore(VectorStore):
                    - Logical: ``{"$and": [{...}, {...}]}``
 
                 Default is None.
+
+            query_embedding (List[float], optional): Pre-computed embedding for
+                the query.cIf not provided, the embedding will be computed using
+                the configured embedding function.
 
             search_strategy (SearchStrategy): The search strategy to use.
                 Default is SearchStrategy.VECTOR_ONLY.
@@ -818,6 +823,7 @@ class SingleStoreVectorStore(VectorStore):
             query=query,
             k=k,
             filter=filter,
+            query_embedding=query_embedding,
             search_strategy=search_strategy,
             filter_threshold=filter_threshold,
             text_weight=text_weight,
@@ -851,6 +857,7 @@ class SingleStoreVectorStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Union[dict, FilterTypedDict]] = None,
+        query_embedding: Optional[List[float]] = None,
         search_strategy: SearchStrategy = SearchStrategy.VECTOR_ONLY,
         filter_threshold: float = 0,
         text_weight: float = 0.5,
@@ -881,6 +888,10 @@ class SingleStoreVectorStore(VectorStore):
                    - Logical: ``{"$and": [{...}, {...}]}``
 
                 Defaults to None.
+
+            query_embedding (List[float], optional): Pre-computed embedding for
+                the query. If not provided, the embedding will be computed using
+                the configured embedding function.
 
             search_strategy (SearchStrategy): The search strategy to use.
                 Default is SearchStrategy.VECTOR_ONLY.
@@ -988,10 +999,12 @@ class SingleStoreVectorStore(VectorStore):
                     host="username:password@localhost:3306/database",
                     use_full_text_search=True,
                     use_vector_index=True,
+                    vector_size=3,
                     full_text_index_version=FullTextIndexVersion.V2,
                 )
                 results = s2.similarity_search_with_score(
                         "query text", 1,
+                        query_embedding=[0.1, 0.2, 0.3], # Pre-computed embedding
                         search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
                         filter_threshold=0.5,
                         full_text_scoring_mode=FullTextScoringMode.BM25,
@@ -1051,7 +1064,10 @@ class SingleStoreVectorStore(VectorStore):
         # Creates embedding vector from user query
         embedding = []
         if search_strategy != SingleStoreVectorStore.SearchStrategy.TEXT_ONLY:
-            embedding = self.embedding.embed_query(query)
+            if query_embedding is not None:
+                embedding = query_embedding
+            else:
+                embedding = self.embedding.embed_query(query)
 
         conn = self.connection_pool.connect()
         result = []
@@ -1220,6 +1236,7 @@ class SingleStoreVectorStore(VectorStore):
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
+        embeddings: Optional[List[List[float]]] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
         table_name: str = "embeddings",
         content_field: str = "content",
@@ -1256,6 +1273,10 @@ class SingleStoreVectorStore(VectorStore):
 
             metadatas (Optional[List[dict]], optional): Optional list of metadatas.
                 Defaults to None.
+
+            embeddings (Optional[List[List[float]]], optional): Optional list of
+              pre-computed embeddings. If not provided, embeddings will be computed
+              using the provided embedding model.
 
             distance_strategy (DistanceStrategy, optional):
                 Determines the strategy employed for calculating
@@ -1417,7 +1438,12 @@ class SingleStoreVectorStore(VectorStore):
             full_text_index_version=full_text_index_version,
             **kwargs,
         )
-        instance.add_texts(texts, metadatas, embedding.embed_documents(texts), **kwargs)
+        instance.add_texts(
+            texts,
+            metadatas,
+            embedding.embed_documents(texts) if embeddings is None else embeddings,
+            **kwargs,
+        )
         return instance
 
     def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -503,6 +503,7 @@ class SingleStoreVectorStore(VectorStore):
         self,
         uris: List[str],
         metadatas: Optional[List[dict]] = None,
+        *,
         embeddings: Optional[List[List[float]]] = None,
         **kwargs: Any,
     ) -> List[str]:
@@ -656,6 +657,7 @@ class SingleStoreVectorStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Union[dict, FilterTypedDict]] = None,
+        *,
         query_embedding: Optional[List[float]] = None,
         search_strategy: SearchStrategy = SearchStrategy.VECTOR_ONLY,
         filter_threshold: float = 0,
@@ -857,6 +859,7 @@ class SingleStoreVectorStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Union[dict, FilterTypedDict]] = None,
+        *,
         query_embedding: Optional[List[float]] = None,
         search_strategy: SearchStrategy = SearchStrategy.VECTOR_ONLY,
         filter_threshold: float = 0,
@@ -1065,6 +1068,10 @@ class SingleStoreVectorStore(VectorStore):
         embedding = []
         if search_strategy != SingleStoreVectorStore.SearchStrategy.TEXT_ONLY:
             if query_embedding is not None:
+                if self.use_vector_index and len(query_embedding) != self.vector_size:
+                    raise ValueError(
+                        "Query embedding size does not match vector size of the index"
+                    )
                 embedding = query_embedding
             else:
                 embedding = self.embedding.embed_query(query)
@@ -1236,6 +1243,7 @@ class SingleStoreVectorStore(VectorStore):
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
+        *,
         embeddings: Optional[List[List[float]]] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
         table_name: str = "embeddings",
@@ -1418,6 +1426,19 @@ class SingleStoreVectorStore(VectorStore):
                     host="username:password@localhost:3306/database"
                 )
         """
+
+        if embeddings is not None and len(embeddings) != len(texts):
+            raise ValueError("The number of embeddings must match the number of texts")
+
+        if (
+            use_vector_index
+            and embeddings is not None
+            and len(embeddings) > 0
+            and vector_size != len(embeddings[0])
+        ):
+            raise ValueError(
+                "Pre-computed embedding size does not match the specified vector_size"
+            )
 
         instance = cls(
             embedding,

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -576,20 +576,22 @@ class SingleStoreVectorStore(VectorStore):
                 or if embedding vector size doesn't match vector_size when using
                 vector index.
         """
-        # Convert texts to list for length validation and iteration
-        texts_list = list(texts)
+        texts_list = []
 
-        if embeddings is not None and len(embeddings) != len(texts_list):
-            raise ValueError("The number of embeddings must match the number of texts")
-
-        if embeddings is not None and self.use_vector_index and len(embeddings) > 0:
-            if any(
-                len(embedding_vector) != self.vector_size
-                for embedding_vector in embeddings
-            ):
+        if embeddings is not None:
+            texts_list = list(texts)
+            if len(embeddings) != len(texts_list):
                 raise ValueError(
-                    "Pre-computed embedding size does not match the vector_size"
+                    "The number of embeddings must match the number of texts"
                 )
+            elif self.use_vector_index and len(embeddings) > 0:
+                if any(
+                    len(embedding_vector) != self.vector_size
+                    for embedding_vector in embeddings
+                ):
+                    raise ValueError(
+                        "Pre-computed embedding size does not match the vector_size"
+                    )
 
         result_ids: List[str] = []
         conn = self.connection_pool.connect()
@@ -597,7 +599,7 @@ class SingleStoreVectorStore(VectorStore):
             cur = conn.cursor()
             try:
                 # Write data to singlestore db
-                for i, text in enumerate(texts_list):
+                for i, text in enumerate(texts if len(texts_list) == 0 else texts_list):
                     # Use provided values by default or fallback
                     metadata = metadatas[i] if metadatas else {}
                     embedding = (

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -528,6 +528,7 @@ class SingleStoreVectorStore(VectorStore):
 
         if (
             embeddings is not None
+            and len(embeddings) > 0
             and self.use_vector_index
             and len(embeddings[0]) != self.vector_size
         ):

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -521,20 +521,24 @@ class SingleStoreVectorStore(VectorStore):
 
         Returns:
             List[str]: list of document ids added to the vectorstore
+
+        Raises:
+            ValueError: If embeddings list length doesn't match uris length.
+            ValueError: If any embedding vector size doesn't match vector_size
+                when use_vector_index is True.
         """
 
         if embeddings is not None and len(embeddings) != len(uris):
             raise ValueError("Length of embeddings must match length of uris")
 
-        if (
-            embeddings is not None
-            and len(embeddings) > 0
-            and self.use_vector_index
-            and len(embeddings[0]) != self.vector_size
-        ):
-            raise ValueError(
-                "Pre-computed embedding size does not match the specified vector_size"
-            )
+        if embeddings is not None and len(embeddings) > 0 and self.use_vector_index:
+            if any(
+                len(embedding_vector) != self.vector_size
+                for embedding_vector in embeddings
+            ):
+                raise ValueError(
+                    "Pre-computed embedding size does not match the vector_size"
+                )
 
         # Set embeddings
         if (
@@ -578,15 +582,14 @@ class SingleStoreVectorStore(VectorStore):
         if embeddings is not None and len(embeddings) != len(texts_list):
             raise ValueError("The number of embeddings must match the number of texts")
 
-        if (
-            embeddings is not None
-            and self.use_vector_index
-            and len(embeddings) > 0
-            and len(embeddings[0]) != self.vector_size
-        ):
-            raise ValueError(
-                "Pre-computed embedding size does not match the specified vector_size"
-            )
+        if embeddings is not None and self.use_vector_index and len(embeddings) > 0:
+            if any(
+                len(embedding_vector) != self.vector_size
+                for embedding_vector in embeddings
+            ):
+                raise ValueError(
+                    "Pre-computed embedding size does not match the vector_size"
+                )
 
         result_ids: List[str] = []
         conn = self.connection_pool.connect()
@@ -798,6 +801,16 @@ class SingleStoreVectorStore(VectorStore):
         Returns:
             List[Document]: A list of documents that are most similar to the query text.
 
+        Raises:
+            ValueError: If search_strategy is not VECTOR_ONLY and
+                use_full_text_search is False.
+            ValueError: If search_strategy is WEIGHTED_SUM and distance_strategy
+                is not DOT_PRODUCT.
+            ValueError: If full_text_scoring_mode is BM25 or BM25_GLOBAL and
+                full_text_index_version is not V2.
+            ValueError: If query_embedding is provided and its size doesn't match
+                vector_size when use_vector_index is True.
+
         Examples:
 
             Basic Usage:
@@ -1002,8 +1015,14 @@ class SingleStoreVectorStore(VectorStore):
             document.
 
         Raises:
-            ValueError: If the search strategy is not supported with the
-                distance strategy.
+            ValueError: If search_strategy is not VECTOR_ONLY and
+                use_full_text_search is False.
+            ValueError: If search_strategy is WEIGHTED_SUM and distance_strategy
+                is not DOT_PRODUCT.
+            ValueError: If full_text_scoring_mode is BM25 or BM25_GLOBAL and
+                full_text_index_version is not V2.
+            ValueError: If query_embedding is provided and its size doesn't match
+                vector_size when use_vector_index is True.
 
         Examples:
             Basic Usage:
@@ -1449,6 +1468,14 @@ class SingleStoreVectorStore(VectorStore):
             results_format (str, optional): Deprecated. This option has been renamed to
                 results_type.
 
+        Returns:
+            SingleStoreVectorStore: A new vectorstore instance with the texts added.
+
+        Raises:
+            ValueError: If embeddings list length doesn't match texts length.
+            ValueError: If any embedding vector size doesn't match vector_size
+                when use_vector_index is True.
+
         Example:
             .. code-block:: python
 
@@ -1466,7 +1493,9 @@ class SingleStoreVectorStore(VectorStore):
             raise ValueError("The number of embeddings must match the number of texts")
 
         if use_vector_index and embeddings is not None and len(embeddings) > 0:
-            if any(len(embedding_vector) != vector_size for embedding_vector in embeddings):
+            if any(
+                len(embedding_vector) != vector_size for embedding_vector in embeddings
+            ):
                 raise ValueError(
                     "All pre-computed embeddings must match the specified vector_size"
                 )

--- a/langchain_singlestore/vectorstores.py
+++ b/langchain_singlestore/vectorstores.py
@@ -1465,15 +1465,11 @@ class SingleStoreVectorStore(VectorStore):
         if embeddings is not None and len(embeddings) != len(texts):
             raise ValueError("The number of embeddings must match the number of texts")
 
-        if (
-            use_vector_index
-            and embeddings is not None
-            and len(embeddings) > 0
-            and vector_size != len(embeddings[0])
-        ):
-            raise ValueError(
-                "Pre-computed embedding size does not match the specified vector_size"
-            )
+        if use_vector_index and embeddings is not None and len(embeddings) > 0:
+            if any(len(embedding_vector) != vector_size for embedding_vector in embeddings):
+                raise ValueError(
+                    "All pre-computed embeddings must match the specified vector_size"
+                )
 
         instance = cls(
             embedding,

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -7,6 +7,7 @@ class is used to ensure the embedding model is never called.
 """
 
 import math
+import os
 import tempfile
 from typing import Generator, List
 
@@ -558,7 +559,11 @@ class TestPrecomputedEmbeddingsAddImages:
             temp_file.close()
             temp_files.append(temp_file.name)
         yield temp_files
-        # Cleanup is handled by tempfile
+        for file in temp_files:
+            try:
+                os.remove(file)
+            except Exception:
+                pass
 
     def test_add_images_with_precomputed_embeddings(
         self,

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -1455,3 +1455,402 @@ class TestPrecomputedEmbeddingsAdvancedFiltering:
         assert len(results) > 0
         for doc in results:
             assert doc.metadata["views"] > 100
+
+
+class TestPrecomputedEmbeddingsValidation:
+    """Test validation of pre-computed embeddings length and vector size."""
+
+    @pytest.fixture
+    def sample_texts(self) -> List[str]:
+        """Sample texts for testing."""
+        return [
+            "The quick brown fox jumps over the lazy dog.",
+            "A journey of a thousand miles begins with a single step.",
+            "To be or not to be, that is the question.",
+        ]
+
+    # ============================================================
+    # add_texts validation tests
+    # ============================================================
+
+    def test_add_texts_validates_embeddings_length_mismatch(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that add_texts raises error when embeddings count doesn't match."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Provide fewer embeddings than texts
+        embeddings = generate_embeddings(2)  # Only 2 embeddings for 3 texts
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_texts(texts=sample_texts, embeddings=embeddings)
+
+        assert "number of embeddings must match the number of texts" in str(
+            exc_info.value
+        )
+
+    def test_add_texts_validates_embeddings_length_too_many(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that add_texts raises error when too many embeddings provided."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Provide more embeddings than texts
+        embeddings = generate_embeddings(5)  # 5 embeddings for 3 texts
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_texts(texts=sample_texts, embeddings=embeddings)
+
+        assert "number of embeddings must match the number of texts" in str(
+            exc_info.value
+        )
+
+    def test_add_texts_validates_vector_size_with_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that add_texts validates vector size matches vector_size setting."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Provide embeddings with wrong dimension (5 instead of 10)
+        wrong_size_embeddings = generate_embeddings(len(sample_texts), size=5)
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_texts(texts=sample_texts, embeddings=wrong_size_embeddings)
+
+        assert "does not match the specified vector_size" in str(exc_info.value)
+
+    def test_add_texts_accepts_correct_vector_size_with_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that add_texts accepts embeddings with correct vector size."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Provide embeddings with correct dimension
+        correct_embeddings = generate_embeddings(len(sample_texts), size=vector_size)
+
+        # Should not raise
+        ids = store.add_texts(texts=sample_texts, embeddings=correct_embeddings)
+        assert len(ids) == len(sample_texts)
+
+    def test_add_texts_no_vector_size_validation_without_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that vector size is not validated when not using vector index."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=False,  # No vector index
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Any embedding size should work without vector index
+        embeddings = generate_embeddings(len(sample_texts), size=5)
+
+        # Should not raise
+        ids = store.add_texts(texts=sample_texts, embeddings=embeddings)
+        assert len(ids) == len(sample_texts)
+
+    # ============================================================
+    # add_images validation tests
+    # ============================================================
+
+    def test_add_images_validates_embeddings_length_mismatch(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test that add_images raises error when embeddings count doesn't match."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        image_uris = ["image1.jpg", "image2.jpg", "image3.jpg"]
+        # Provide fewer embeddings than images
+        embeddings = generate_embeddings(2)  # Only 2 embeddings for 3 images
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_images(uris=image_uris, embeddings=embeddings)
+
+        assert "Length of embeddings must match length of uris" in str(exc_info.value)
+
+    def test_add_images_validates_embeddings_length_too_many(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test that add_images raises error when too many embeddings provided."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        image_uris = ["image1.jpg", "image2.jpg", "image3.jpg"]
+        # Provide more embeddings than images
+        embeddings = generate_embeddings(5)  # 5 embeddings for 3 images
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_images(uris=image_uris, embeddings=embeddings)
+
+        assert "Length of embeddings must match length of uris" in str(exc_info.value)
+
+    def test_add_images_validates_vector_size_with_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test that add_images validates vector size matches vector_size setting."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        image_uris = ["image1.jpg", "image2.jpg", "image3.jpg"]
+        # Provide embeddings with wrong dimension (5 instead of 10)
+        wrong_size_embeddings = generate_embeddings(len(image_uris), size=5)
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_images(uris=image_uris, embeddings=wrong_size_embeddings)
+
+        assert "does not match the specified vector_size" in str(exc_info.value)
+
+    def test_add_images_accepts_correct_vector_size_with_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test that add_images accepts embeddings with correct vector size."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        image_uris = ["image1.jpg", "image2.jpg", "image3.jpg"]
+        # Provide embeddings with correct dimension
+        correct_embeddings = generate_embeddings(len(image_uris), size=vector_size)
+
+        # Should not raise
+        ids = store.add_images(uris=image_uris, embeddings=correct_embeddings)
+        assert len(ids) == len(image_uris)
+
+    # ============================================================
+    # add_documents validation tests (via add_texts)
+    # ============================================================
+
+    def test_add_documents_validates_embeddings_length_mismatch(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test that add_documents raises error when embeddings count doesn't match."""
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        documents = [
+            Document(page_content="doc 1"),
+            Document(page_content="doc 2"),
+            Document(page_content="doc 3"),
+        ]
+        # Provide fewer embeddings than documents
+        embeddings = generate_embeddings(2)  # Only 2 embeddings for 3 documents
+
+        with pytest.raises(ValueError) as exc_info:
+            store.add_documents(documents=documents, embeddings=embeddings)
+
+        assert "number of embeddings must match the number of texts" in str(
+            exc_info.value
+        )
+
+    # ============================================================
+    # from_texts validation tests
+    # ============================================================
+
+    def test_from_texts_validates_embeddings_length_mismatch(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test that from_texts raises error when embeddings count doesn't match."""
+        # Provide fewer embeddings than texts
+        embeddings = generate_embeddings(2)  # Only 2 embeddings for 3 texts
+
+        with pytest.raises(ValueError) as exc_info:
+            store_tracker.create_from_texts(
+                texts=sample_texts,
+                embedding=ErrorEmbeddings(),
+                embeddings=embeddings,
+                host=clean_db_url,
+                database=TEST_DB_NAME,
+            )
+
+        assert "number of embeddings must match the number of texts" in str(
+            exc_info.value
+        )
+
+    # ============================================================
+    # from_documents validation tests (via from_texts)
+    # ============================================================
+
+    def test_from_documents_validates_embeddings_length_mismatch(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+    ) -> None:
+        """Test from_documents raises error when embeddings count doesn't match."""
+        documents = [
+            Document(page_content="doc 1"),
+            Document(page_content="doc 2"),
+            Document(page_content="doc 3"),
+        ]
+        # Provide fewer embeddings than documents
+        embeddings = generate_embeddings(2)  # Only 2 embeddings for 3 documents
+
+        with pytest.raises(ValueError) as exc_info:
+            store_tracker.create_from_documents(
+                documents=documents,
+                embedding=ErrorEmbeddings(),
+                embeddings=embeddings,
+                host=clean_db_url,
+                database=TEST_DB_NAME,
+            )
+
+        assert "number of embeddings must match the number of texts" in str(
+            exc_info.value
+        )
+
+    # ============================================================
+    # similarity_search query_embedding validation tests
+    # ============================================================
+
+    def test_similarity_search_validates_query_embedding_size_with_vector_index(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test similarity_search validates query embedding size with vector index."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Add texts with correct embedding size
+        correct_embeddings = generate_embeddings(len(sample_texts), size=vector_size)
+        store.add_texts(texts=sample_texts, embeddings=correct_embeddings)
+
+        # Try to search with wrong query embedding size (5 instead of 10)
+        wrong_query_embedding = generate_embedding(0, size=5)
+
+        with pytest.raises(ValueError) as exc_info:
+            store.similarity_search(
+                query="test",
+                k=1,
+                query_embedding=wrong_query_embedding,
+            )
+
+        assert "does not match vector size" in str(exc_info.value)
+
+    def test_similarity_search_accepts_correct_query_embedding_size(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test similarity_search accepts query embedding with correct size."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Add texts with correct embedding size
+        correct_embeddings = generate_embeddings(len(sample_texts), size=vector_size)
+        store.add_texts(texts=sample_texts, embeddings=correct_embeddings)
+
+        # Search with correct query embedding size
+        correct_query_embedding = generate_embedding(0, size=vector_size)
+
+        # Should not raise
+        results = store.similarity_search(
+            query="test",
+            k=1,
+            query_embedding=correct_query_embedding,
+        )
+        assert len(results) == 1
+
+    def test_similarity_search_with_score_validates_query_embedding_size(
+        self,
+        store_tracker: StoreTracker,
+        clean_db_url: str,
+        sample_texts: List[str],
+    ) -> None:
+        """Test similarity_search_with_score validates query embedding size."""
+        vector_size = 10
+        store = store_tracker.create(
+            embedding=ErrorEmbeddings(),
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        # Add texts with correct embedding size
+        correct_embeddings = generate_embeddings(len(sample_texts), size=vector_size)
+        store.add_texts(texts=sample_texts, embeddings=correct_embeddings)
+
+        # Try to search with wrong query embedding size
+        wrong_query_embedding = generate_embedding(0, size=5)
+
+        with pytest.raises(ValueError) as exc_info:
+            store.similarity_search_with_score(
+                query="test",
+                k=1,
+                query_embedding=wrong_query_embedding,
+            )
+
+        assert "does not match vector size" in str(exc_info.value)

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -1,0 +1,1452 @@
+"""
+Integration tests for SingleStoreVectorStore with pre-computed embeddings.
+
+These tests verify that the vectorstore works correctly when users provide
+pre-computed embeddings, bypassing the embedding model entirely. The ErrorEmbeddings
+class is used to ensure the embedding model is never called.
+"""
+
+import math
+import tempfile
+from typing import Generator, List
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+
+from langchain_singlestore._utils import (
+    DistanceStrategy,
+    FullTextIndexVersion,
+    FullTextScoringMode,
+)
+from langchain_singlestore.vectorstores import SingleStoreVectorStore
+from tests.integration_tests.conftest import TEST_DB_NAME
+
+
+class ErrorEmbeddings(Embeddings):
+    """Fake embeddings that raises an error. For testing purposes.
+
+    This class is used to verify that pre-computed embeddings are being used
+    instead of calling the embedding model. If the vectorstore accidentally
+    tries to compute embeddings, the test will fail with a clear error.
+    """
+
+    def embed_query(self, text: str) -> List[float]:
+        raise ValueError(
+            "Embedding model was called when it should not have been. "
+            "Pre-computed embeddings should be used instead."
+        )
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        raise ValueError(
+            "Embedding model was called when it should not have been. "
+            "Pre-computed embeddings should be used instead."
+        )
+
+    def embed_image(self, uris: List[str]) -> List[List[float]]:
+        raise ValueError(
+            "Embedding model was called when it should not have been. "
+            "Pre-computed embeddings should be used instead."
+        )
+
+
+def generate_embedding(index: int, size: int = 10) -> List[float]:
+    """Generate a deterministic embedding for testing.
+
+    Uses trigonometric functions to create embeddings that have
+    predictable similarity relationships.
+
+    Args:
+        index: The document index (affects the angle used)
+        size: The embedding dimension
+
+    Returns:
+        A list of floats representing the embedding
+    """
+    return [math.cos((index + i) * math.pi / size) for i in range(size)]
+
+
+def generate_embeddings(count: int, size: int = 10) -> List[List[float]]:
+    """Generate multiple deterministic embeddings for testing.
+
+    Args:
+        count: Number of embeddings to generate
+        size: The embedding dimension
+
+    Returns:
+        A list of embeddings
+    """
+    return [generate_embedding(i, size) for i in range(count)]
+
+
+class TestPrecomputedEmbeddingsVectorStoreCreation:
+    """Test vectorstore creation methods with pre-computed embeddings."""
+
+    @pytest.fixture
+    def sample_texts(self) -> List[str]:
+        """Sample texts for testing."""
+        return [
+            "The quick brown fox jumps over the lazy dog.",
+            "A journey of a thousand miles begins with a single step.",
+            "To be or not to be, that is the question.",
+        ]
+
+    @pytest.fixture
+    def sample_metadatas(self) -> List[dict]:
+        """Sample metadata for testing."""
+        return [
+            {"source": "proverb", "category": "animals"},
+            {"source": "proverb", "category": "wisdom"},
+            {"source": "shakespeare", "category": "philosophy"},
+        ]
+
+    @pytest.fixture
+    def sample_documents(
+        self, sample_texts: List[str], sample_metadatas: List[dict]
+    ) -> List[Document]:
+        """Sample documents for testing."""
+        return [
+            Document(page_content=text, metadata=meta)
+            for text, meta in zip(sample_texts, sample_metadatas)
+        ]
+
+    @pytest.fixture
+    def precomputed_embeddings(self, sample_texts: List[str]) -> List[List[float]]:
+        """Pre-computed embeddings for sample texts."""
+        return generate_embeddings(len(sample_texts))
+
+    # ============================================================
+    # Constructor creation tests
+    # ============================================================
+
+    def test_constructor_add_texts_with_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        sample_metadatas: List[dict],
+        precomputed_embeddings: List[List[float]],
+    ) -> None:
+        """Test creating vectorstore with constructor and add_texts with embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            ids = store.add_texts(
+                texts=sample_texts,
+                metadatas=sample_metadatas,
+                embeddings=precomputed_embeddings,
+            )
+            assert len(ids) == len(sample_texts)
+
+            # Verify search works with pre-computed query embedding
+            results = store.similarity_search(
+                query="fox",
+                k=1,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[0]
+        finally:
+            store.drop()
+
+    def test_constructor_add_documents_with_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        sample_documents: List[Document],
+        precomputed_embeddings: List[List[float]],
+    ) -> None:
+        """Test vectorstore with constructor and add_documents with embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            ids = store.add_documents(
+                documents=sample_documents,
+                embeddings=precomputed_embeddings,
+            )
+            assert len(ids) == len(sample_documents)
+
+            results = store.similarity_search(
+                query="any",
+                k=3,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 3
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy",
+        [DistanceStrategy.DOT_PRODUCT, DistanceStrategy.EUCLIDEAN_DISTANCE],
+    )
+    def test_constructor_with_different_distance_strategies(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        precomputed_embeddings: List[List[float]],
+        distance_strategy: DistanceStrategy,
+    ) -> None:
+        """Test vectorstore creation with different distance strategies."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            distance_strategy=distance_strategy,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=sample_texts,
+                embeddings=precomputed_embeddings,
+            )
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=precomputed_embeddings[2],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[2]
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy,vector_size,index_options",
+        [
+            (DistanceStrategy.DOT_PRODUCT, 10, None),
+            (DistanceStrategy.EUCLIDEAN_DISTANCE, 10, None),
+            (
+                DistanceStrategy.EUCLIDEAN_DISTANCE,
+                10,
+                {"index_type": "IVF_PQ", "nlist": 256},
+            ),
+        ],
+    )
+    def test_constructor_with_vector_index(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        distance_strategy: DistanceStrategy,
+        vector_size: int,
+        index_options: dict,
+    ) -> None:
+        """Test vectorstore creation with vector index enabled."""
+        embeddings = generate_embeddings(len(sample_texts), vector_size)
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            distance_strategy=distance_strategy,
+            use_vector_index=True,
+            vector_size=vector_size,
+            vector_index_options=index_options,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(texts=sample_texts, embeddings=embeddings)
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=embeddings[2],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[2]
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_constructor_with_fulltext_index(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        precomputed_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test vectorstore creation with fulltext index enabled."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(texts=sample_texts, embeddings=precomputed_embeddings)
+            results = store.similarity_search(
+                query=sample_texts[1],
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[1]
+        finally:
+            store.drop()
+
+    # ============================================================
+    # from_texts creation tests
+    # ============================================================
+
+    def test_from_texts_with_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        sample_metadatas: List[dict],
+        precomputed_embeddings: List[List[float]],
+    ) -> None:
+        """Test from_texts with pre-computed embeddings."""
+        store = SingleStoreVectorStore.from_texts(
+            texts=sample_texts,
+            embedding=ErrorEmbeddings(),
+            metadatas=sample_metadatas,
+            embeddings=precomputed_embeddings,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=3,
+                query_embedding=precomputed_embeddings[1],
+            )
+            assert len(results) == 3
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy",
+        [DistanceStrategy.DOT_PRODUCT, DistanceStrategy.EUCLIDEAN_DISTANCE],
+    )
+    def test_from_texts_with_different_distance_strategies(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        precomputed_embeddings: List[List[float]],
+        distance_strategy: DistanceStrategy,
+    ) -> None:
+        """Test from_texts with different distance strategies."""
+        store = SingleStoreVectorStore.from_texts(
+            texts=sample_texts,
+            embedding=ErrorEmbeddings(),
+            embeddings=precomputed_embeddings,
+            distance_strategy=distance_strategy,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[0]
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy,vector_size",
+        [
+            (DistanceStrategy.DOT_PRODUCT, 10),
+            (DistanceStrategy.EUCLIDEAN_DISTANCE, 10),
+        ],
+    )
+    def test_from_texts_with_vector_index(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        distance_strategy: DistanceStrategy,
+        vector_size: int,
+    ) -> None:
+        """Test from_texts with vector index enabled."""
+        embeddings = generate_embeddings(len(sample_texts), vector_size)
+        store = SingleStoreVectorStore.from_texts(
+            texts=sample_texts,
+            embedding=ErrorEmbeddings(),
+            embeddings=embeddings,
+            distance_strategy=distance_strategy,
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=embeddings[2],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[2]
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_from_texts_with_fulltext_index(
+        self,
+        clean_db_url: str,
+        sample_texts: List[str],
+        precomputed_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test from_texts with fulltext index enabled."""
+        store = SingleStoreVectorStore.from_texts(
+            texts=sample_texts,
+            embedding=ErrorEmbeddings(),
+            embeddings=precomputed_embeddings,
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query=sample_texts[1],
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_texts[1]
+        finally:
+            store.drop()
+
+    # ============================================================
+    # from_documents creation tests
+    # ============================================================
+
+    def test_from_documents_with_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        sample_documents: List[Document],
+        precomputed_embeddings: List[List[float]],
+    ) -> None:
+        """Test from_documents with pre-computed embeddings."""
+        store = SingleStoreVectorStore.from_documents(
+            documents=sample_documents,
+            embedding=ErrorEmbeddings(),
+            embeddings=precomputed_embeddings,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=3,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 3
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy",
+        [DistanceStrategy.DOT_PRODUCT, DistanceStrategy.EUCLIDEAN_DISTANCE],
+    )
+    def test_from_documents_with_different_distance_strategies(
+        self,
+        clean_db_url: str,
+        sample_documents: List[Document],
+        precomputed_embeddings: List[List[float]],
+        distance_strategy: DistanceStrategy,
+    ) -> None:
+        """Test from_documents with different distance strategies."""
+        store = SingleStoreVectorStore.from_documents(
+            documents=sample_documents,
+            embedding=ErrorEmbeddings(),
+            embeddings=precomputed_embeddings,
+            distance_strategy=distance_strategy,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_documents[0].page_content
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "distance_strategy,vector_size",
+        [
+            (DistanceStrategy.DOT_PRODUCT, 10),
+            (DistanceStrategy.EUCLIDEAN_DISTANCE, 10),
+        ],
+    )
+    def test_from_documents_with_vector_index(
+        self,
+        clean_db_url: str,
+        sample_documents: List[Document],
+        distance_strategy: DistanceStrategy,
+        vector_size: int,
+    ) -> None:
+        """Test from_documents with vector index enabled."""
+        embeddings = generate_embeddings(len(sample_documents), vector_size)
+        store = SingleStoreVectorStore.from_documents(
+            documents=sample_documents,
+            embedding=ErrorEmbeddings(),
+            embeddings=embeddings,
+            distance_strategy=distance_strategy,
+            use_vector_index=True,
+            vector_size=vector_size,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query="any",
+                k=1,
+                query_embedding=embeddings[2],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_documents[2].page_content
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_from_documents_with_fulltext_index(
+        self,
+        clean_db_url: str,
+        sample_documents: List[Document],
+        precomputed_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test from_documents with fulltext index enabled."""
+        store = SingleStoreVectorStore.from_documents(
+            documents=sample_documents,
+            embedding=ErrorEmbeddings(),
+            embeddings=precomputed_embeddings,
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            results = store.similarity_search(
+                query=sample_documents[1].page_content,
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            )
+            assert len(results) == 1
+            assert results[0].page_content == sample_documents[1].page_content
+        finally:
+            store.drop()
+
+
+class TestPrecomputedEmbeddingsAddImages:
+    """Test add_images with pre-computed embeddings."""
+
+    @pytest.fixture
+    def temp_image_files(self) -> Generator[List[str], None, None]:
+        """Create temporary files to simulate images."""
+        temp_files = []
+        for i in range(3):
+            temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".jpg")
+            temp_file.write(f"fake image content {i}".encode())
+            temp_file.close()
+            temp_files.append(temp_file.name)
+        yield temp_files
+        # Cleanup is handled by tempfile
+
+    def test_add_images_with_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        temp_image_files: List[str],
+    ) -> None:
+        """Test adding images with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            precomputed_embeddings = generate_embeddings(len(temp_image_files))
+            ids = store.add_images(
+                uris=temp_image_files,
+                embeddings=precomputed_embeddings,
+            )
+            assert len(ids) == len(temp_image_files)
+
+            # Search using pre-computed query embedding
+            results = store.similarity_search(
+                query="image",
+                k=1,
+                query_embedding=precomputed_embeddings[0],
+            )
+            assert len(results) == 1
+            assert results[0].page_content == temp_image_files[0]
+        finally:
+            store.drop()
+
+    def test_add_images_with_metadatas_and_precomputed_embeddings(
+        self,
+        clean_db_url: str,
+        temp_image_files: List[str],
+    ) -> None:
+        """Test adding images with metadata and pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            precomputed_embeddings = generate_embeddings(len(temp_image_files))
+            metadatas = [
+                {"index": i, "type": "image"} for i in range(len(temp_image_files))
+            ]
+            ids = store.add_images(
+                uris=temp_image_files,
+                metadatas=metadatas,
+                embeddings=precomputed_embeddings,
+            )
+            assert len(ids) == len(temp_image_files)
+
+            results = store.similarity_search(
+                query="image",
+                k=3,
+                query_embedding=precomputed_embeddings[1],
+                filter={"type": "image"},
+            )
+            assert len(results) == 3
+        finally:
+            store.drop()
+
+
+class TestPrecomputedEmbeddingsSimilaritySearch:
+    """Test similarity search methods with pre-computed embeddings."""
+
+    @pytest.fixture
+    def snow_rain_texts(self) -> List[str]:
+        """Sample texts about snow and rain."""
+        return [
+            "In the parched desert, a sudden rainstorm brought relief.",
+            "Amidst the bustling cityscape, the rain fell relentlessly.",
+            "High in the mountains, the rain transformed into a delicate mist.",
+            "Blanketing the countryside, the snowfall painted a serene tableau.",
+            "In the urban landscape, snow descended, transforming streets.",
+            "Atop the rugged peaks, snow fell with unyielding intensity.",
+        ]
+
+    @pytest.fixture
+    def snow_rain_metadatas(self) -> List[dict]:
+        """Metadata for snow/rain texts."""
+        return [
+            {"count": "1", "category": "rain", "group": "a"},
+            {"count": "2", "category": "rain", "group": "a"},
+            {"count": "3", "category": "rain", "group": "b"},
+            {"count": "1", "category": "snow", "group": "b"},
+            {"count": "2", "category": "snow", "group": "a"},
+            {"count": "3", "category": "snow", "group": "a"},
+        ]
+
+    @pytest.fixture
+    def snow_rain_documents(
+        self, snow_rain_texts: List[str], snow_rain_metadatas: List[dict]
+    ) -> List[Document]:
+        """Sample documents about snow and rain."""
+        return [
+            Document(page_content=text, metadata=meta)
+            for text, meta in zip(snow_rain_texts, snow_rain_metadatas)
+        ]
+
+    @pytest.fixture
+    def snow_rain_embeddings(self, snow_rain_texts: List[str]) -> List[List[float]]:
+        """Pre-computed embeddings for snow/rain texts."""
+        return generate_embeddings(len(snow_rain_texts))
+
+    # ============================================================
+    # VECTOR_ONLY search strategy tests
+    # ============================================================
+
+    def test_similarity_search_vector_only(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+    ) -> None:
+        """Test VECTOR_ONLY search with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm",
+                k=3,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY,
+            )
+            assert len(results) == 3
+            # First result should be the most similar (index 0)
+            assert results[0].page_content == snow_rain_texts[0]
+        finally:
+            store.drop()
+
+    def test_similarity_search_vector_only_with_filter(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+    ) -> None:
+        """Test VECTOR_ONLY search with metadata filter."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm",
+                k=3,
+                query_embedding=snow_rain_embeddings[0],
+                filter={"category": "snow"},
+            )
+            assert len(results) == 3
+            for doc in results:
+                assert doc.metadata["category"] == "snow"
+        finally:
+            store.drop()
+
+    def test_similarity_search_with_score_vector_only(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+    ) -> None:
+        """Test similarity_search_with_score with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search_with_score(
+                query="rainstorm",
+                k=3,
+                query_embedding=snow_rain_embeddings[0],
+            )
+            assert len(results) == 3
+            # Results should be tuples of (Document, score)
+            for doc, score in results:
+                assert isinstance(doc, Document)
+                assert isinstance(score, float)
+        finally:
+            store.drop()
+
+    # ============================================================
+    # TEXT_ONLY search strategy tests
+    # ============================================================
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_similarity_search_text_only(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test TEXT_ONLY search (embedding not needed for search)."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            # TEXT_ONLY doesn't need query_embedding
+            results = store.similarity_search(
+                query="rainstorm parched desert",
+                k=3,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            )
+            assert len(results) >= 1
+            # The first text mentions "parched desert" and "rainstorm"
+            assert "parched desert" in results[0].page_content
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_similarity_search_text_only_scoring_modes_v2(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_scoring_mode: FullTextScoringMode,
+    ) -> None:
+        """Test TEXT_ONLY search with different scoring modes (V2 index)."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="snowfall countryside",
+                k=1,
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(results) == 1
+            # Should find the document about snowfall in countryside
+            assert (
+                "countryside" in results[0].page_content
+                or "snow" in results[0].page_content
+            )
+        finally:
+            store.drop()
+
+    # ============================================================
+    # FILTER_BY_TEXT search strategy tests
+    # ============================================================
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_similarity_search_filter_by_text(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test FILTER_BY_TEXT search with pre-computed embeddings."""
+        threshold = 1 if full_text_index_version == FullTextIndexVersion.V2 else 0
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm parched desert",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
+                filter_threshold=threshold,
+            )
+            assert len(results) == 1
+            assert "parched desert" in results[0].page_content
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_similarity_search_filter_by_text_scoring_modes_v2(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_scoring_mode: FullTextScoringMode,
+    ) -> None:
+        """Test FILTER_BY_TEXT with different scoring modes (V2 index)."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm parched desert",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
+                filter_threshold=0.2,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(results) == 1
+        finally:
+            store.drop()
+
+    # ============================================================
+    # FILTER_BY_VECTOR search strategy tests
+    # ============================================================
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_similarity_search_filter_by_vector(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test FILTER_BY_VECTOR search with pre-computed embeddings."""
+        threshold = 0.2 if full_text_index_version == FullTextIndexVersion.V2 else -0.2
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm desert rain",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                filter={"category": "rain"},
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
+                filter_threshold=threshold,
+            )
+            assert len(results) >= 1
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_similarity_search_filter_by_vector_scoring_modes_v2(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_scoring_mode: FullTextScoringMode,
+    ) -> None:
+        """Test FILTER_BY_VECTOR with different scoring modes (V2 index)."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm desert rain",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
+                filter_threshold=-10.0,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(results) == 1
+        finally:
+            store.drop()
+
+    # ============================================================
+    # WEIGHTED_SUM search strategy tests
+    # ============================================================
+
+    @pytest.mark.parametrize(
+        "full_text_index_version",
+        [FullTextIndexVersion.V1, FullTextIndexVersion.V2],
+    )
+    def test_similarity_search_weighted_sum(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_index_version: FullTextIndexVersion,
+    ) -> None:
+        """Test WEIGHTED_SUM search with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=full_text_index_version,
+            distance_strategy=DistanceStrategy.DOT_PRODUCT,  # Required for WEIGHTED_SUM
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm desert rain",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+                text_weight=0.3,
+                vector_weight=0.7,
+            )
+            assert len(results) == 1
+        finally:
+            store.drop()
+
+    def test_similarity_search_weighted_sum_with_filter(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+    ) -> None:
+        """Test WEIGHTED_SUM search with metadata filter."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            distance_strategy=DistanceStrategy.DOT_PRODUCT,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="rainstorm desert rain",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                filter={"category": "snow"},
+                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+            )
+            assert len(results) == 1
+            assert results[0].metadata["category"] == "snow"
+        finally:
+            store.drop()
+
+    @pytest.mark.parametrize(
+        "full_text_scoring_mode",
+        [
+            FullTextScoringMode.BM25,
+            FullTextScoringMode.BM25_GLOBAL,
+            FullTextScoringMode.MATCH,
+        ],
+    )
+    def test_similarity_search_weighted_sum_scoring_modes_v2(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_metadatas: List[dict],
+        snow_rain_embeddings: List[List[float]],
+        full_text_scoring_mode: FullTextScoringMode,
+    ) -> None:
+        """Test WEIGHTED_SUM with different scoring modes (V2 index)."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            distance_strategy=DistanceStrategy.DOT_PRODUCT,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=snow_rain_texts,
+                metadatas=snow_rain_metadatas,
+                embeddings=snow_rain_embeddings,
+            )
+            results = store.similarity_search(
+                query="snowfall countryside",
+                k=1,
+                query_embedding=snow_rain_embeddings[3],  # Use embedding for snow text
+                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+                text_weight=0.5,
+                vector_weight=0.5,
+                full_text_scoring_mode=full_text_scoring_mode,
+            )
+            assert len(results) == 1
+        finally:
+            store.drop()
+
+    # ============================================================
+    # Error case: WEIGHTED_SUM with EUCLIDEAN_DISTANCE
+    # ============================================================
+
+    def test_weighted_sum_unsupported_with_euclidean(
+        self,
+        clean_db_url: str,
+        snow_rain_texts: List[str],
+        snow_rain_embeddings: List[List[float]],
+    ) -> None:
+        """Test that WEIGHTED_SUM raises error with EUCLIDEAN_DISTANCE."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(texts=snow_rain_texts, embeddings=snow_rain_embeddings)
+            with pytest.raises(ValueError) as exc_info:
+                store.similarity_search(
+                    query="test",
+                    k=1,
+                    query_embedding=snow_rain_embeddings[0],
+                    search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+                )
+            assert "Search strategy SearchStrategy.WEIGHTED_SUM is not" in str(
+                exc_info.value
+            )
+        finally:
+            store.drop()
+
+
+class TestPrecomputedEmbeddingsAdvancedFiltering:
+    """Test advanced FilterTypedDict filtering with pre-computed embeddings."""
+
+    @pytest.fixture
+    def numeric_texts(self) -> List[str]:
+        """Product texts for filter testing."""
+        return [
+            "Product A with 100 views",
+            "Product B with 200 views",
+            "Product C with 50 views",
+            "Product D with 300 views",
+            "Product E with 150 views",
+        ]
+
+    @pytest.fixture
+    def numeric_metadatas(self) -> List[dict]:
+        """Product metadata for filter testing."""
+        return [
+            {"name": "A", "views": 100, "rating": 4.5, "active": True},
+            {"name": "B", "views": 200, "rating": 4.0, "active": True},
+            {"name": "C", "views": 50, "rating": 3.5, "active": False},
+            {"name": "D", "views": 300, "rating": 5.0, "active": True},
+            {"name": "E", "views": 150, "rating": 4.2, "active": False},
+        ]
+
+    @pytest.fixture
+    def numeric_embeddings(self, numeric_texts: List[str]) -> List[List[float]]:
+        """Pre-computed embeddings for products."""
+        return generate_embeddings(len(numeric_texts))
+
+    def test_filter_eq_operator(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test $eq operator with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={"name": {"$eq": "B"}},
+            )
+            assert len(results) == 1
+            assert results[0].metadata["name"] == "B"
+        finally:
+            store.drop()
+
+    def test_filter_gt_operator(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test $gt operator with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={"views": {"$gt": 150}},
+            )
+            assert len(results) == 2
+            names = [doc.metadata["name"] for doc in results]
+            assert "B" in names  # 200 views
+            assert "D" in names  # 300 views
+        finally:
+            store.drop()
+
+    def test_filter_in_operator(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test $in operator with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={"name": {"$in": ["A", "C"]}},
+            )
+            assert len(results) == 2
+            names = [doc.metadata["name"] for doc in results]
+            assert "A" in names
+            assert "C" in names
+        finally:
+            store.drop()
+
+    def test_filter_and_operator(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test $and operator with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={
+                    "$and": [
+                        {"views": {"$gt": 100}},
+                        {"active": True},
+                    ]
+                },
+            )
+            # Products with views > 100 AND active=True: B (200), D (300)
+            assert len(results) == 2
+            names = [doc.metadata["name"] for doc in results]
+            assert "B" in names
+            assert "D" in names
+        finally:
+            store.drop()
+
+    def test_filter_or_operator(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test $or operator with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={
+                    "$or": [
+                        {"name": "A"},
+                        {"rating": {"$gte": 5.0}},
+                    ]
+                },
+            )
+            # name=A OR rating >= 5.0: A (4.5 but name matches), D (5.0)
+            assert len(results) >= 2
+            names = [doc.metadata["name"] for doc in results]
+            assert "A" in names
+            assert "D" in names
+        finally:
+            store.drop()
+
+    def test_complex_nested_filter(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test complex nested $and/$or filter with pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            results = store.similarity_search(
+                query="product",
+                k=10,
+                query_embedding=numeric_embeddings[0],
+                filter={
+                    "$and": [
+                        {
+                            "$or": [
+                                {"name": "A"},
+                                {"name": "B"},
+                            ]
+                        },
+                        {"views": {"$gte": 150}},
+                    ]
+                },
+            )
+            # (name=A OR name=B) AND views >= 150: B (200)
+            assert len(results) == 1
+            assert results[0].metadata["name"] == "B"
+        finally:
+            store.drop()
+
+    def test_filter_with_search_strategy(
+        self,
+        clean_db_url: str,
+        numeric_texts: List[str],
+        numeric_metadatas: List[dict],
+        numeric_embeddings: List[List[float]],
+    ) -> None:
+        """Test FilterTypedDict with TEXT_ONLY search and pre-computed embeddings."""
+        store = SingleStoreVectorStore(
+            embedding=ErrorEmbeddings(),
+            use_full_text_search=True,
+            full_text_index_version=FullTextIndexVersion.V2,
+            host=clean_db_url,
+            database=TEST_DB_NAME,
+        )
+        try:
+            store.add_texts(
+                texts=numeric_texts,
+                metadatas=numeric_metadatas,
+                embeddings=numeric_embeddings,
+            )
+            # TEXT_ONLY doesn't need query_embedding
+            results = store.similarity_search(
+                query="product views",
+                k=10,
+                filter={"views": {"$gt": 100}},
+                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            )
+            assert len(results) > 0
+            for doc in results:
+                assert doc.metadata["views"] > 100
+        finally:
+            store.drop()

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -60,10 +60,7 @@ class StoreTracker:
     def cleanup(self) -> None:
         """Drop all tracked stores."""
         for store in self._stores:
-            try:
-                store.drop()
-            except Exception:
-                pass  # Ignore errors during cleanup
+            store.drop()
         self._stores.clear()
 
 

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -9,7 +9,7 @@ class is used to ensure the embedding model is never called.
 import math
 import os
 import tempfile
-from typing import Generator, List
+from typing import Any, Generator, List
 
 import pytest
 from langchain_core.documents import Document
@@ -22,6 +22,70 @@ from langchain_singlestore._utils import (
 )
 from langchain_singlestore.vectorstores import SingleStoreVectorStore
 from tests.integration_tests.conftest import TEST_DB_NAME
+
+
+class StoreTracker:
+    """Tracks SingleStoreVectorStore instances for automatic cleanup.
+
+    Usage:
+        def test_something(self, store_tracker):
+            store = store_tracker.create(embedding=..., host=..., database=...)
+            # ... test code ...
+            # store.drop() is called automatically after the test
+    """
+
+    def __init__(self) -> None:
+        self._stores: List[SingleStoreVectorStore] = []
+
+    def track(self, store: SingleStoreVectorStore) -> SingleStoreVectorStore:
+        """Register a store for automatic cleanup."""
+        self._stores.append(store)
+        return store
+
+    def create(self, **kwargs: Any) -> SingleStoreVectorStore:
+        """Create and track a new SingleStoreVectorStore."""
+        store = SingleStoreVectorStore(**kwargs)
+        return self.track(store)
+
+    def create_from_texts(self, **kwargs: Any) -> SingleStoreVectorStore:
+        """Create from texts and track a new SingleStoreVectorStore."""
+        store = SingleStoreVectorStore.from_texts(**kwargs)
+        return self.track(store)
+
+    def create_from_documents(self, **kwargs: Any) -> SingleStoreVectorStore:
+        """Create from documents and track a new SingleStoreVectorStore."""
+        store = SingleStoreVectorStore.from_documents(**kwargs)
+        return self.track(store)
+
+    def cleanup(self) -> None:
+        """Drop all tracked stores."""
+        for store in self._stores:
+            try:
+                store.drop()
+            except Exception:
+                pass  # Ignore errors during cleanup
+        self._stores.clear()
+
+
+@pytest.fixture
+def store_tracker() -> Generator[StoreTracker, None, None]:
+    """Fixture that provides automatic cleanup for vectorstores.
+
+    Example:
+        def test_my_test(self, store_tracker, clean_db_url):
+            store = store_tracker.create(
+                embedding=ErrorEmbeddings(),
+                host=clean_db_url,
+                database=TEST_DB_NAME,
+            )
+            store.add_texts(...)  # use the store
+            # No need for try/finally - cleanup is automatic
+    """
+    tracker = StoreTracker()
+    try:
+        yield tracker
+    finally:
+        tracker.cleanup()
 
 
 class ErrorEmbeddings(Embeddings):
@@ -122,63 +186,59 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
 
     def test_constructor_add_texts_with_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         sample_metadatas: List[dict],
         precomputed_embeddings: List[List[float]],
     ) -> None:
         """Test creating vectorstore with constructor and add_texts with embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            ids = store.add_texts(
-                texts=sample_texts,
-                metadatas=sample_metadatas,
-                embeddings=precomputed_embeddings,
-            )
-            assert len(ids) == len(sample_texts)
+        ids = store.add_texts(
+            texts=sample_texts,
+            metadatas=sample_metadatas,
+            embeddings=precomputed_embeddings,
+        )
+        assert len(ids) == len(sample_texts)
 
-            # Verify search works with pre-computed query embedding
-            results = store.similarity_search(
-                query="fox",
-                k=1,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[0]
-        finally:
-            store.drop()
+        # Verify search works with pre-computed query embedding
+        results = store.similarity_search(
+            query="fox",
+            k=1,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[0]
 
     def test_constructor_add_documents_with_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_documents: List[Document],
         precomputed_embeddings: List[List[float]],
     ) -> None:
         """Test vectorstore with constructor and add_documents with embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            ids = store.add_documents(
-                documents=sample_documents,
-                embeddings=precomputed_embeddings,
-            )
-            assert len(ids) == len(sample_documents)
+        ids = store.add_documents(
+            documents=sample_documents,
+            embeddings=precomputed_embeddings,
+        )
+        assert len(ids) == len(sample_documents)
 
-            results = store.similarity_search(
-                query="any",
-                k=3,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 3
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=3,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 3
 
     @pytest.mark.parametrize(
         "distance_strategy",
@@ -186,32 +246,30 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_constructor_with_different_distance_strategies(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         precomputed_embeddings: List[List[float]],
         distance_strategy: DistanceStrategy,
     ) -> None:
         """Test vectorstore creation with different distance strategies."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             distance_strategy=distance_strategy,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=sample_texts,
-                embeddings=precomputed_embeddings,
-            )
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=precomputed_embeddings[2],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[2]
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=sample_texts,
+            embeddings=precomputed_embeddings,
+        )
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=precomputed_embeddings[2],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[2]
 
     @pytest.mark.parametrize(
         "distance_strategy,vector_size,index_options",
@@ -227,6 +285,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_constructor_with_vector_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         distance_strategy: DistanceStrategy,
@@ -235,7 +294,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     ) -> None:
         """Test vectorstore creation with vector index enabled."""
         embeddings = generate_embeddings(len(sample_texts), vector_size)
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             distance_strategy=distance_strategy,
             use_vector_index=True,
@@ -244,17 +303,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(texts=sample_texts, embeddings=embeddings)
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=embeddings[2],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[2]
-        finally:
-            store.drop()
+        store.add_texts(texts=sample_texts, embeddings=embeddings)
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=embeddings[2],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[2]
 
     @pytest.mark.parametrize(
         "full_text_index_version",
@@ -262,30 +318,28 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_constructor_with_fulltext_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         precomputed_embeddings: List[List[float]],
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test vectorstore creation with fulltext index enabled."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=full_text_index_version,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(texts=sample_texts, embeddings=precomputed_embeddings)
-            results = store.similarity_search(
-                query=sample_texts[1],
-                k=1,
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[1]
-        finally:
-            store.drop()
+        store.add_texts(texts=sample_texts, embeddings=precomputed_embeddings)
+        results = store.similarity_search(
+            query=sample_texts[1],
+            k=1,
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[1]
 
     # ============================================================
     # from_texts creation tests
@@ -293,13 +347,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
 
     def test_from_texts_with_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         sample_metadatas: List[dict],
         precomputed_embeddings: List[List[float]],
     ) -> None:
         """Test from_texts with pre-computed embeddings."""
-        store = SingleStoreVectorStore.from_texts(
+        store = store_tracker.create_from_texts(
             texts=sample_texts,
             embedding=ErrorEmbeddings(),
             metadatas=sample_metadatas,
@@ -307,15 +362,12 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=3,
-                query_embedding=precomputed_embeddings[1],
-            )
-            assert len(results) == 3
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=3,
+            query_embedding=precomputed_embeddings[1],
+        )
+        assert len(results) == 3
 
     @pytest.mark.parametrize(
         "distance_strategy",
@@ -323,13 +375,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_texts_with_different_distance_strategies(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         precomputed_embeddings: List[List[float]],
         distance_strategy: DistanceStrategy,
     ) -> None:
         """Test from_texts with different distance strategies."""
-        store = SingleStoreVectorStore.from_texts(
+        store = store_tracker.create_from_texts(
             texts=sample_texts,
             embedding=ErrorEmbeddings(),
             embeddings=precomputed_embeddings,
@@ -337,16 +390,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[0]
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[0]
 
     @pytest.mark.parametrize(
         "distance_strategy,vector_size",
@@ -357,6 +407,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_texts_with_vector_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         distance_strategy: DistanceStrategy,
@@ -364,7 +415,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     ) -> None:
         """Test from_texts with vector index enabled."""
         embeddings = generate_embeddings(len(sample_texts), vector_size)
-        store = SingleStoreVectorStore.from_texts(
+        store = store_tracker.create_from_texts(
             texts=sample_texts,
             embedding=ErrorEmbeddings(),
             embeddings=embeddings,
@@ -374,16 +425,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=embeddings[2],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[2]
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=embeddings[2],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[2]
 
     @pytest.mark.parametrize(
         "full_text_index_version",
@@ -391,13 +439,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_texts_with_fulltext_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_texts: List[str],
         precomputed_embeddings: List[List[float]],
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test from_texts with fulltext index enabled."""
-        store = SingleStoreVectorStore.from_texts(
+        store = store_tracker.create_from_texts(
             texts=sample_texts,
             embedding=ErrorEmbeddings(),
             embeddings=precomputed_embeddings,
@@ -406,16 +455,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query=sample_texts[1],
-                k=1,
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_texts[1]
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query=sample_texts[1],
+            k=1,
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_texts[1]
 
     # ============================================================
     # from_documents creation tests
@@ -423,27 +469,25 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
 
     def test_from_documents_with_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_documents: List[Document],
         precomputed_embeddings: List[List[float]],
     ) -> None:
         """Test from_documents with pre-computed embeddings."""
-        store = SingleStoreVectorStore.from_documents(
+        store = store_tracker.create_from_documents(
             documents=sample_documents,
             embedding=ErrorEmbeddings(),
             embeddings=precomputed_embeddings,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=3,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 3
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=3,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 3
 
     @pytest.mark.parametrize(
         "distance_strategy",
@@ -451,13 +495,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_documents_with_different_distance_strategies(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_documents: List[Document],
         precomputed_embeddings: List[List[float]],
         distance_strategy: DistanceStrategy,
     ) -> None:
         """Test from_documents with different distance strategies."""
-        store = SingleStoreVectorStore.from_documents(
+        store = store_tracker.create_from_documents(
             documents=sample_documents,
             embedding=ErrorEmbeddings(),
             embeddings=precomputed_embeddings,
@@ -465,16 +510,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_documents[0].page_content
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_documents[0].page_content
 
     @pytest.mark.parametrize(
         "distance_strategy,vector_size",
@@ -485,6 +527,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_documents_with_vector_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_documents: List[Document],
         distance_strategy: DistanceStrategy,
@@ -492,7 +535,7 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     ) -> None:
         """Test from_documents with vector index enabled."""
         embeddings = generate_embeddings(len(sample_documents), vector_size)
-        store = SingleStoreVectorStore.from_documents(
+        store = store_tracker.create_from_documents(
             documents=sample_documents,
             embedding=ErrorEmbeddings(),
             embeddings=embeddings,
@@ -502,16 +545,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query="any",
-                k=1,
-                query_embedding=embeddings[2],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_documents[2].page_content
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="any",
+            k=1,
+            query_embedding=embeddings[2],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_documents[2].page_content
 
     @pytest.mark.parametrize(
         "full_text_index_version",
@@ -519,13 +559,14 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
     )
     def test_from_documents_with_fulltext_index(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         sample_documents: List[Document],
         precomputed_embeddings: List[List[float]],
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test from_documents with fulltext index enabled."""
-        store = SingleStoreVectorStore.from_documents(
+        store = store_tracker.create_from_documents(
             documents=sample_documents,
             embedding=ErrorEmbeddings(),
             embeddings=precomputed_embeddings,
@@ -534,16 +575,13 @@ class TestPrecomputedEmbeddingsVectorStoreCreation:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            results = store.similarity_search(
-                query=sample_documents[1].page_content,
-                k=1,
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-            )
-            assert len(results) == 1
-            assert results[0].page_content == sample_documents[1].page_content
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query=sample_documents[1].page_content,
+            k=1,
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+        )
+        assert len(results) == 1
+        assert results[0].page_content == sample_documents[1].page_content
 
 
 class TestPrecomputedEmbeddingsAddImages:
@@ -567,66 +605,62 @@ class TestPrecomputedEmbeddingsAddImages:
 
     def test_add_images_with_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         temp_image_files: List[str],
     ) -> None:
         """Test adding images with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            precomputed_embeddings = generate_embeddings(len(temp_image_files))
-            ids = store.add_images(
-                uris=temp_image_files,
-                embeddings=precomputed_embeddings,
-            )
-            assert len(ids) == len(temp_image_files)
+        precomputed_embeddings = generate_embeddings(len(temp_image_files))
+        ids = store.add_images(
+            uris=temp_image_files,
+            embeddings=precomputed_embeddings,
+        )
+        assert len(ids) == len(temp_image_files)
 
-            # Search using pre-computed query embedding
-            results = store.similarity_search(
-                query="image",
-                k=1,
-                query_embedding=precomputed_embeddings[0],
-            )
-            assert len(results) == 1
-            assert results[0].page_content == temp_image_files[0]
-        finally:
-            store.drop()
+        # Search using pre-computed query embedding
+        results = store.similarity_search(
+            query="image",
+            k=1,
+            query_embedding=precomputed_embeddings[0],
+        )
+        assert len(results) == 1
+        assert results[0].page_content == temp_image_files[0]
 
     def test_add_images_with_metadatas_and_precomputed_embeddings(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         temp_image_files: List[str],
     ) -> None:
         """Test adding images with metadata and pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            precomputed_embeddings = generate_embeddings(len(temp_image_files))
-            metadatas = [
-                {"index": i, "type": "image"} for i in range(len(temp_image_files))
-            ]
-            ids = store.add_images(
-                uris=temp_image_files,
-                metadatas=metadatas,
-                embeddings=precomputed_embeddings,
-            )
-            assert len(ids) == len(temp_image_files)
+        precomputed_embeddings = generate_embeddings(len(temp_image_files))
+        metadatas = [
+            {"index": i, "type": "image"} for i in range(len(temp_image_files))
+        ]
+        ids = store.add_images(
+            uris=temp_image_files,
+            metadatas=metadatas,
+            embeddings=precomputed_embeddings,
+        )
+        assert len(ids) == len(temp_image_files)
 
-            results = store.similarity_search(
-                query="image",
-                k=3,
-                query_embedding=precomputed_embeddings[1],
-                filter={"type": "image"},
-            )
-            assert len(results) == 3
-        finally:
-            store.drop()
+        results = store.similarity_search(
+            query="image",
+            k=3,
+            query_embedding=precomputed_embeddings[1],
+            filter={"type": "image"},
+        )
+        assert len(results) == 3
 
 
 class TestPrecomputedEmbeddingsSimilaritySearch:
@@ -677,97 +711,91 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
 
     def test_similarity_search_vector_only(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
         snow_rain_embeddings: List[List[float]],
     ) -> None:
         """Test VECTOR_ONLY search with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm",
-                k=3,
-                query_embedding=snow_rain_embeddings[0],
-                search_strategy=SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY,
-            )
-            assert len(results) == 3
-            # First result should be the most similar (index 0)
-            assert results[0].page_content == snow_rain_texts[0]
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm",
+            k=3,
+            query_embedding=snow_rain_embeddings[0],
+            search_strategy=SingleStoreVectorStore.SearchStrategy.VECTOR_ONLY,
+        )
+        assert len(results) == 3
+        # First result should be the most similar (index 0)
+        assert results[0].page_content == snow_rain_texts[0]
 
     def test_similarity_search_vector_only_with_filter(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
         snow_rain_embeddings: List[List[float]],
     ) -> None:
         """Test VECTOR_ONLY search with metadata filter."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm",
-                k=3,
-                query_embedding=snow_rain_embeddings[0],
-                filter={"category": "snow"},
-            )
-            assert len(results) == 3
-            for doc in results:
-                assert doc.metadata["category"] == "snow"
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm",
+            k=3,
+            query_embedding=snow_rain_embeddings[0],
+            filter={"category": "snow"},
+        )
+        assert len(results) == 3
+        for doc in results:
+            assert doc.metadata["category"] == "snow"
 
     def test_similarity_search_with_score_vector_only(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
         snow_rain_embeddings: List[List[float]],
     ) -> None:
         """Test similarity_search_with_score with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search_with_score(
-                query="rainstorm",
-                k=3,
-                query_embedding=snow_rain_embeddings[0],
-            )
-            assert len(results) == 3
-            # Results should be tuples of (Document, score)
-            for doc, score in results:
-                assert isinstance(doc, Document)
-                assert isinstance(score, float)
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search_with_score(
+            query="rainstorm",
+            k=3,
+            query_embedding=snow_rain_embeddings[0],
+        )
+        assert len(results) == 3
+        # Results should be tuples of (Document, score)
+        for doc, score in results:
+            assert isinstance(doc, Document)
+            assert isinstance(score, float)
 
     # ============================================================
     # TEXT_ONLY search strategy tests
@@ -779,6 +807,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_text_only(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -786,30 +815,27 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test TEXT_ONLY search (embedding not needed for search)."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=full_text_index_version,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            # TEXT_ONLY doesn't need query_embedding
-            results = store.similarity_search(
-                query="rainstorm parched desert",
-                k=3,
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-            )
-            assert len(results) >= 1
-            # The first text mentions "parched desert" and "rainstorm"
-            assert "parched desert" in results[0].page_content
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        # TEXT_ONLY doesn't need query_embedding
+        results = store.similarity_search(
+            query="rainstorm parched desert",
+            k=3,
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+        )
+        assert len(results) >= 1
+        # The first text mentions "parched desert" and "rainstorm"
+        assert "parched desert" in results[0].page_content
 
     @pytest.mark.parametrize(
         "full_text_scoring_mode",
@@ -821,6 +847,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_text_only_scoring_modes_v2(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -828,33 +855,30 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_scoring_mode: FullTextScoringMode,
     ) -> None:
         """Test TEXT_ONLY search with different scoring modes (V2 index)."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="snowfall countryside",
-                k=1,
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-                full_text_scoring_mode=full_text_scoring_mode,
-            )
-            assert len(results) == 1
-            # Should find the document about snowfall in countryside
-            assert (
-                "countryside" in results[0].page_content
-                or "snow" in results[0].page_content
-            )
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="snowfall countryside",
+            k=1,
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+            full_text_scoring_mode=full_text_scoring_mode,
+        )
+        assert len(results) == 1
+        # Should find the document about snowfall in countryside
+        assert (
+            "countryside" in results[0].page_content
+            or "snow" in results[0].page_content
+        )
 
     # ============================================================
     # FILTER_BY_TEXT search strategy tests
@@ -866,6 +890,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_filter_by_text(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -874,30 +899,28 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     ) -> None:
         """Test FILTER_BY_TEXT search with pre-computed embeddings."""
         threshold = 1 if full_text_index_version == FullTextIndexVersion.V2 else 0
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=full_text_index_version,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm parched desert",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
-                filter_threshold=threshold,
-            )
-            assert len(results) == 1
-            assert "parched desert" in results[0].page_content
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm parched desert",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
+            filter_threshold=threshold,
+        )
+        assert len(results) == 1
+        assert "parched desert" in results[0].page_content
 
     @pytest.mark.parametrize(
         "full_text_scoring_mode",
@@ -909,6 +932,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_filter_by_text_scoring_modes_v2(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -916,30 +940,27 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_scoring_mode: FullTextScoringMode,
     ) -> None:
         """Test FILTER_BY_TEXT with different scoring modes (V2 index)."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm parched desert",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
-                filter_threshold=0.2,
-                full_text_scoring_mode=full_text_scoring_mode,
-            )
-            assert len(results) == 1
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm parched desert",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_TEXT,
+            filter_threshold=0.2,
+            full_text_scoring_mode=full_text_scoring_mode,
+        )
+        assert len(results) == 1
 
     # ============================================================
     # FILTER_BY_VECTOR search strategy tests
@@ -951,6 +972,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_filter_by_vector(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -959,30 +981,28 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     ) -> None:
         """Test FILTER_BY_VECTOR search with pre-computed embeddings."""
         threshold = 0.2 if full_text_index_version == FullTextIndexVersion.V2 else -0.2
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=full_text_index_version,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm desert rain",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                filter={"category": "rain"},
-                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
-                filter_threshold=threshold,
-            )
-            assert len(results) >= 1
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm desert rain",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            filter={"category": "rain"},
+            search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
+            filter_threshold=threshold,
+        )
+        assert len(results) >= 1
 
     @pytest.mark.parametrize(
         "full_text_scoring_mode",
@@ -994,6 +1014,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_filter_by_vector_scoring_modes_v2(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -1001,30 +1022,28 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_scoring_mode: FullTextScoringMode,
     ) -> None:
         """Test FILTER_BY_VECTOR with different scoring modes (V2 index)."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm desert rain",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
-                filter_threshold=-10.0,
-                full_text_scoring_mode=full_text_scoring_mode,
-            )
-            assert len(results) == 1
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm desert rain",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            search_strategy=SingleStoreVectorStore.SearchStrategy.FILTER_BY_VECTOR,
+            filter_threshold=-10.0,
+            full_text_scoring_mode=full_text_scoring_mode,
+        )
+        assert len(results) == 1
 
     # ============================================================
     # WEIGHTED_SUM search strategy tests
@@ -1036,6 +1055,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_weighted_sum(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -1043,7 +1063,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test WEIGHTED_SUM search with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=full_text_index_version,
@@ -1051,33 +1071,32 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm desert rain",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
-                text_weight=0.3,
-                vector_weight=0.7,
-            )
-            assert len(results) == 1
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm desert rain",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+            text_weight=0.3,
+            vector_weight=0.7,
+        )
+        assert len(results) == 1
 
     def test_similarity_search_weighted_sum_with_filter(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
         snow_rain_embeddings: List[List[float]],
     ) -> None:
         """Test WEIGHTED_SUM search with metadata filter."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
@@ -1085,23 +1104,20 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="rainstorm desert rain",
-                k=1,
-                query_embedding=snow_rain_embeddings[0],
-                filter={"category": "snow"},
-                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
-            )
-            assert len(results) == 1
-            assert results[0].metadata["category"] == "snow"
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="rainstorm desert rain",
+            k=1,
+            query_embedding=snow_rain_embeddings[0],
+            filter={"category": "snow"},
+            search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+        )
+        assert len(results) == 1
+        assert results[0].metadata["category"] == "snow"
 
     @pytest.mark.parametrize(
         "full_text_scoring_mode",
@@ -1113,6 +1129,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
     )
     def test_similarity_search_weighted_sum_scoring_modes_v2(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_metadatas: List[dict],
@@ -1120,7 +1137,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_scoring_mode: FullTextScoringMode,
     ) -> None:
         """Test WEIGHTED_SUM with different scoring modes (V2 index)."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
@@ -1128,24 +1145,22 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=snow_rain_texts,
-                metadatas=snow_rain_metadatas,
-                embeddings=snow_rain_embeddings,
-            )
-            results = store.similarity_search(
-                query="snowfall countryside",
-                k=1,
-                query_embedding=snow_rain_embeddings[3],  # Use embedding for snow text
-                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
-                text_weight=0.5,
-                vector_weight=0.5,
-                full_text_scoring_mode=full_text_scoring_mode,
-            )
-            assert len(results) == 1
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=snow_rain_texts,
+            metadatas=snow_rain_metadatas,
+            embeddings=snow_rain_embeddings,
+        )
+        results = store.similarity_search(
+            query="snowfall countryside",
+            k=1,
+            query_embedding=snow_rain_embeddings[3],  # Use embedding for snow text
+            search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
+            text_weight=0.5,
+            vector_weight=0.5,
+            full_text_scoring_mode=full_text_scoring_mode,
+        )
+        assert len(results) == 1
 
     # ============================================================
     # Error case: WEIGHTED_SUM with EUCLIDEAN_DISTANCE
@@ -1153,32 +1168,30 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
 
     def test_weighted_sum_unsupported_with_euclidean(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         snow_rain_texts: List[str],
         snow_rain_embeddings: List[List[float]],
     ) -> None:
         """Test that WEIGHTED_SUM raises error with EUCLIDEAN_DISTANCE."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(texts=snow_rain_texts, embeddings=snow_rain_embeddings)
-            with pytest.raises(ValueError) as exc_info:
-                store.similarity_search(
-                    query="test",
-                    k=1,
-                    query_embedding=snow_rain_embeddings[0],
-                    search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
-                )
-            assert "Search strategy SearchStrategy.WEIGHTED_SUM is not" in str(
-                exc_info.value
+        store.add_texts(texts=snow_rain_texts, embeddings=snow_rain_embeddings)
+        with pytest.raises(ValueError) as exc_info:
+            store.similarity_search(
+                query="test",
+                k=1,
+                query_embedding=snow_rain_embeddings[0],
+                search_strategy=SingleStoreVectorStore.SearchStrategy.WEIGHTED_SUM,
             )
-        finally:
-            store.drop()
+        assert "Search strategy SearchStrategy.WEIGHTED_SUM is not" in str(
+            exc_info.value
+        )
 
 
 class TestPrecomputedEmbeddingsAdvancedFiltering:
@@ -1213,245 +1226,232 @@ class TestPrecomputedEmbeddingsAdvancedFiltering:
 
     def test_filter_eq_operator(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test $eq operator with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={"name": {"$eq": "B"}},
-            )
-            assert len(results) == 1
-            assert results[0].metadata["name"] == "B"
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={"name": {"$eq": "B"}},
+        )
+        assert len(results) == 1
+        assert results[0].metadata["name"] == "B"
 
     def test_filter_gt_operator(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test $gt operator with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={"views": {"$gt": 150}},
-            )
-            assert len(results) == 2
-            names = [doc.metadata["name"] for doc in results]
-            assert "B" in names  # 200 views
-            assert "D" in names  # 300 views
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={"views": {"$gt": 150}},
+        )
+        assert len(results) == 2
+        names = [doc.metadata["name"] for doc in results]
+        assert "B" in names  # 200 views
+        assert "D" in names  # 300 views
 
     def test_filter_in_operator(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test $in operator with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={"name": {"$in": ["A", "C"]}},
-            )
-            assert len(results) == 2
-            names = [doc.metadata["name"] for doc in results]
-            assert "A" in names
-            assert "C" in names
-        finally:
-            store.drop()
+
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={"name": {"$in": ["A", "C"]}},
+        )
+        assert len(results) == 2
+        names = [doc.metadata["name"] for doc in results]
+        assert "A" in names
+        assert "C" in names
 
     def test_filter_and_operator(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test $and operator with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={
-                    "$and": [
-                        {"views": {"$gt": 100}},
-                        {"active": True},
-                    ]
-                },
-            )
-            # Products with views > 100 AND active=True: B (200), D (300)
-            assert len(results) == 2
-            names = [doc.metadata["name"] for doc in results]
-            assert "B" in names
-            assert "D" in names
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={
+                "$and": [
+                    {"views": {"$gt": 100}},
+                    {"active": True},
+                ]
+            },
+        )
+        # Products with views > 100 AND active=True: B (200), D (300)
+        assert len(results) == 2
+        names = [doc.metadata["name"] for doc in results]
+        assert "B" in names
+        assert "D" in names
 
     def test_filter_or_operator(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test $or operator with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={
-                    "$or": [
-                        {"name": "A"},
-                        {"rating": {"$gte": 5.0}},
-                    ]
-                },
-            )
-            # name=A OR rating >= 5.0: A (4.5 but name matches), D (5.0)
-            assert len(results) >= 2
-            names = [doc.metadata["name"] for doc in results]
-            assert "A" in names
-            assert "D" in names
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={
+                "$or": [
+                    {"name": "A"},
+                    {"rating": {"$gte": 5.0}},
+                ]
+            },
+        )
+        # name=A OR rating >= 5.0: A (4.5 but name matches), D (5.0)
+        assert len(results) >= 2
+        names = [doc.metadata["name"] for doc in results]
+        assert "A" in names
+        assert "D" in names
 
     def test_complex_nested_filter(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test complex nested $and/$or filter with pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            results = store.similarity_search(
-                query="product",
-                k=10,
-                query_embedding=numeric_embeddings[0],
-                filter={
-                    "$and": [
-                        {
-                            "$or": [
-                                {"name": "A"},
-                                {"name": "B"},
-                            ]
-                        },
-                        {"views": {"$gte": 150}},
-                    ]
-                },
-            )
-            # (name=A OR name=B) AND views >= 150: B (200)
-            assert len(results) == 1
-            assert results[0].metadata["name"] == "B"
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        results = store.similarity_search(
+            query="product",
+            k=10,
+            query_embedding=numeric_embeddings[0],
+            filter={
+                "$and": [
+                    {
+                        "$or": [
+                            {"name": "A"},
+                            {"name": "B"},
+                        ]
+                    },
+                    {"views": {"$gte": 150}},
+                ]
+            },
+        )
+        # (name=A OR name=B) AND views >= 150: B (200)
+        assert len(results) == 1
+        assert results[0].metadata["name"] == "B"
 
     def test_filter_with_search_strategy(
         self,
+        store_tracker: StoreTracker,
         clean_db_url: str,
         numeric_texts: List[str],
         numeric_metadatas: List[dict],
         numeric_embeddings: List[List[float]],
     ) -> None:
         """Test FilterTypedDict with TEXT_ONLY search and pre-computed embeddings."""
-        store = SingleStoreVectorStore(
+        store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
             full_text_index_version=FullTextIndexVersion.V2,
             host=clean_db_url,
             database=TEST_DB_NAME,
         )
-        try:
-            store.add_texts(
-                texts=numeric_texts,
-                metadatas=numeric_metadatas,
-                embeddings=numeric_embeddings,
-            )
-            # TEXT_ONLY doesn't need query_embedding
-            results = store.similarity_search(
-                query="product views",
-                k=10,
-                filter={"views": {"$gt": 100}},
-                search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
-            )
-            assert len(results) > 0
-            for doc in results:
-                assert doc.metadata["views"] > 100
-        finally:
-            store.drop()
+        store.add_texts(
+            texts=numeric_texts,
+            metadatas=numeric_metadatas,
+            embeddings=numeric_embeddings,
+        )
+        # TEXT_ONLY doesn't need query_embedding
+        results = store.similarity_search(
+            query="product views",
+            k=10,
+            filter={"views": {"$gt": 100}},
+            search_strategy=SingleStoreVectorStore.SearchStrategy.TEXT_ONLY,
+        )
+        assert len(results) > 0
+        for doc in results:
+            assert doc.metadata["views"] > 100

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -980,11 +980,7 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test FILTER_BY_VECTOR search with pre-computed embeddings."""
-        threshold = (
-            0.2
-            if full_text_index_version == FullTextIndexVersion.V2
-            else -0.2
-        )
+        threshold = 0.2 if full_text_index_version == FullTextIndexVersion.V2 else -0.2
         store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,
@@ -1542,7 +1538,7 @@ class TestPrecomputedEmbeddingsValidation:
         with pytest.raises(ValueError) as exc_info:
             store.add_texts(texts=sample_texts, embeddings=wrong_size_embeddings)
 
-        assert "does not match the specified vector_size" in str(exc_info.value)
+        assert "does not match the vector_size" in str(exc_info.value)
 
     def test_add_texts_accepts_correct_vector_size_with_vector_index(
         self,
@@ -1651,7 +1647,7 @@ class TestPrecomputedEmbeddingsValidation:
         with pytest.raises(ValueError) as exc_info:
             store.add_images(uris=image_uris, embeddings=wrong_size_embeddings)
 
-        assert "does not match the specified vector_size" in str(exc_info.value)
+        assert "does not match the vector_size" in str(exc_info.value)
 
     def test_add_images_accepts_correct_vector_size_with_vector_index(
         self,

--- a/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
+++ b/tests/integration_tests/test_vectorstores_with_precomputed_embeddings.py
@@ -980,7 +980,11 @@ class TestPrecomputedEmbeddingsSimilaritySearch:
         full_text_index_version: FullTextIndexVersion,
     ) -> None:
         """Test FILTER_BY_VECTOR search with pre-computed embeddings."""
-        threshold = 0.2 if full_text_index_version == FullTextIndexVersion.V2 else -0.2
+        threshold = (
+            0.2
+            if full_text_index_version == FullTextIndexVersion.V2
+            else -0.2
+        )
         store = store_tracker.create(
             embedding=ErrorEmbeddings(),
             use_full_text_search=True,


### PR DESCRIPTION
- Added support for pre-computed embeddings (when emebedding model should not be called by the vectorstore object, because all vectors are provided by the user)
- Added integration tests for the funcionality
- Updated README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public `SingleStoreVectorStore` APIs (new keyword-only params and stricter validation) and alters how embeddings are sourced during insert/search, which could break callers relying on positional arguments or mismatched vector sizes.
> 
> **Overview**
> Adds first-class support for *pre-computed embeddings* in `SingleStoreVectorStore`, allowing callers to supply vectors for `add_texts`/`add_images`/`from_texts` and to pass a `query_embedding` for `similarity_search`/`similarity_search_with_score` to bypass embedding-model calls.
> 
> Introduces input validation to enforce embedding count alignment and (when `use_vector_index` is enabled) vector dimensionality checks, plus extensive new integration coverage verifying the embedding model is never invoked and behavior works across search strategies, scoring modes, and filters. Documentation is expanded with a new README section and examples for supplying pre-computed embeddings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ed3168e72e222de60e62c46a3e676ee9b2bb75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->